### PR TITLE
feat(ui): apply Light Pro visual refresh

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,63 +1,66 @@
 :root{
-  --bg:#f2f5fa;
+  --bg:#f5f7fa;
   --surface:#ffffff;
   --surface-soft:#f8fbff;
-  --stroke:#d6e0ec;
+  --stroke:#e3e8ef;
   --text:#0f172a;
   --muted:#64748b;
-  --accent:#0d9488;
-  --accent-soft:#e7fbf9;
+  --accent:#0ea5a4;
+  --accent-soft:#e6fffb;
   --shadow-sm:0 6px 20px rgba(15,23,42,.06);
-  --shadow-md:0 16px 40px rgba(15,23,42,.09);
+  --shadow-md:0 12px 30px rgba(15,23,42,.08);
   --radius:18px;
 }
 
 *{box-sizing:border-box}
 html,body{height:100%;scroll-behavior:smooth}
-body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;background:var(--bg);color:var(--text)}
+body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;background:var(--bg);color:var(--text);line-height:1.45}
 a{color:inherit;text-decoration:none}
 .container{width:min(1140px, calc(100% - 32px));margin:0 auto}
 
-.topbar{position:sticky;top:0;z-index:50;background:rgba(242,245,250,.92);backdrop-filter:blur(12px);border-bottom:1px solid var(--stroke)}
+.topbar{position:sticky;top:0;z-index:50;background:rgba(245,247,250,.92);backdrop-filter:blur(12px);border-bottom:1px solid var(--stroke)}
 .topbar__inner{display:flex;align-items:center;justify-content:space-between;gap:14px;padding:12px 0}
 .brand{display:flex;align-items:center;gap:10px}
 .brand__dot{width:12px;height:12px;border-radius:999px;background:var(--accent);box-shadow:0 0 0 4px var(--accent-soft)}
 .brand small{color:var(--muted)}
 .nav{display:flex;gap:8px}
-.nav a{padding:8px 11px;border-radius:999px;color:var(--muted);font-weight:600}
-.nav a:hover{color:var(--accent);background:#fff}
+.nav a{padding:9px 13px;border-radius:999px;color:var(--muted);font-weight:600;transition:.2s ease}
+.nav a:hover{color:var(--accent);background:#fff;box-shadow:var(--shadow-sm)}
 .topbar__cta{display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end}
 
-.btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:12px 14px;border-radius:12px;border:1px solid var(--stroke);background:var(--surface);color:var(--text);font-weight:700;cursor:pointer;transition:.2s ease}
-.btn:hover{border-color:var(--accent);transform:translateY(-1px)}
+.btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:12px 16px;border-radius:14px;border:1px solid var(--stroke);background:var(--surface);color:var(--text);font-weight:700;cursor:pointer;transition:.2s ease}
+.btn:hover{border-color:var(--accent);transform:translateY(-1px);box-shadow:var(--shadow-sm)}
 .btn:focus-visible,input:focus-visible,select:focus-visible,.segmentMenu__btn:focus-visible{outline:3px solid rgba(13,148,136,.24);outline-offset:1px}
 .btn--primary{background:var(--accent);color:#fff;border-color:var(--accent)}
-.btn--ghost{background:#fff}
+.btn--primary:hover{background:#0b9a99;border-color:#0b9a99}
+.btn--ghost{background:#fff;color:#0f172a}
 .btn--wide{width:100%;padding:14px}
 
-.hero{padding:32px 0 18px}
+.hero{padding:36px 0 24px}
 .kicker{display:inline-flex;padding:7px 11px;border-radius:999px;background:var(--accent-soft);color:var(--accent);font-weight:700;font-size:12px}
-.hero h1{margin:12px 0 8px;font-size:clamp(30px,5vw,48px);line-height:1.08;max-width:22ch}
-.hero p{margin:0;color:var(--muted);max-width:64ch}
+.hero h1{margin:14px 0 10px;font-size:clamp(30px,5vw,48px);line-height:1.08;max-width:22ch;letter-spacing:-.02em}
+.hero p{margin:0;color:var(--muted);max-width:64ch;font-size:16px}
 .hero__microcopy{display:block;margin-top:7px;color:var(--muted)}
 
-.segmentMenu{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:8px;margin:8px 0 22px}
-.segmentMenu__btn{padding:12px;border:1px solid var(--stroke);background:#fff;border-radius:12px;font-weight:700;color:#1e293b;cursor:pointer}
-.segmentMenu__btn:hover{border-color:var(--accent);color:var(--accent)}
+.segmentMenu{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:8px;margin:8px 0 26px;padding:8px;background:#fff;border:1px solid var(--stroke);border-radius:16px;box-shadow:var(--shadow-sm)}
+.segmentMenu__btn{padding:12px;border:1px solid transparent;background:#fff;border-radius:12px;font-weight:700;color:#1e293b;cursor:pointer;transition:.2s ease}
+.segmentMenu__btn:hover,.segmentMenu__btn:focus-visible{border-color:#b7ece8;background:var(--accent-soft);color:var(--accent)}
+.segmentMenu__btn:active{background:var(--accent);color:#fff;border-color:var(--accent)}
 
-.sectionCard{border:1px solid var(--stroke);background:var(--surface-soft);border-radius:var(--radius);box-shadow:var(--shadow-sm);padding:18px;margin:0 0 20px}
+.sectionCard{border:1px solid var(--stroke);background:var(--surface);border-radius:var(--radius);box-shadow:var(--shadow-sm);padding:28px;margin:0 0 24px}
 .sectionCard h2{margin:0;font-size:25px;letter-spacing:-.01em}
-.sectionMicrocopy{margin:6px 0 14px;color:var(--muted)}
+.sectionMicrocopy{margin:8px 0 18px;color:var(--muted);font-size:14px}
 
-.grid{display:grid;grid-template-columns:1.15fr .85fr;gap:16px}
+.grid{display:grid;grid-template-columns:1.15fr .85fr;gap:20px}
 .card{border-radius:16px;border:1px solid var(--stroke);background:#fff;box-shadow:var(--shadow-sm)}
-.card__inner{padding:16px}
+.card__inner{padding:24px}
 .card h2{margin:0 0 12px;font-size:20px}
 
 .field{margin-bottom:13px}
-.label{font-weight:600;color:#334155;font-size:12px;margin-bottom:7px}
+.label{font-weight:600;color:#475569;font-size:12px;margin-bottom:7px;letter-spacing:.01em}
 .label-row{display:flex;align-items:center;justify-content:space-between;gap:8px}
-input,select{width:100%;padding:13px 12px;border:1px solid #c7d3e2;border-radius:12px;background:#fff;color:var(--text);font-size:15px}
+input,select{width:100%;padding:13px 12px;border:1px solid #d4dce8;border-radius:12px;background:#fff;color:var(--text);font-size:15px;transition:.2s ease}
+input:hover,select:hover{border-color:#b8c5d7}
 .row2{display:grid;grid-template-columns:1fr 1fr;gap:10px}
 .hint{margin:8px 0 12px;padding:10px;border:1px solid var(--stroke);background:#f8fafc;border-radius:12px;color:var(--muted);font-size:12px;line-height:1.4}
 .toggle{margin:8px 0 12px;display:flex;flex-direction:column;gap:6px;font-size:12px;color:var(--muted)}
@@ -66,7 +69,7 @@ input,select{width:100%;padding:13px 12px;border:1px solid #c7d3e2;border-radius
 .check--inline{margin-bottom:10px}
 .hidden{display:none!important}
 
-.cardMini{margin-top:12px;border-radius:14px;border:1px solid var(--stroke);background:#fff;padding:11px}
+.cardMini{margin-top:14px;border-radius:14px;border:1px solid var(--stroke);background:#fff;padding:14px}
 .cardMini__header{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px}
 .pill{padding:5px 9px;border-radius:999px;background:var(--accent-soft);color:var(--accent);font-size:11px;font-weight:700;border:1px solid #bcefeb}
 .advGrid{display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:8px}
@@ -74,8 +77,8 @@ input,select{width:100%;padding:13px 12px;border:1px solid #c7d3e2;border-radius
 .advItem--wide{grid-column:1/-1}
 .affGrid{display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px;margin-top:10px}
 
-.resultList,.marketCompareList{display:flex;flex-direction:column;gap:10px}
-.heroBox{padding:12px;border-radius:12px;border:1px solid #bcefeb;background:var(--accent-soft);margin-bottom:10px}
+.resultList,.marketCompareList{display:flex;flex-direction:column;gap:12px}
+.heroBox{padding:14px;border-radius:14px;border:1px solid #bcefeb;background:var(--accent-soft);margin-bottom:10px}
 .heroLabel{font-size:11px;letter-spacing:.08em;font-weight:700;color:#0f766e}
 .heroValue{font-size:clamp(28px,4.2vw,38px);font-weight:800;line-height:1.1}
 .resultGrid{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:8px 10px}
@@ -84,7 +87,7 @@ input,select{width:100%;padding:13px 12px;border:1px solid #c7d3e2;border-radius
 .cardDivider{height:1px;background:#e2e8f0;margin:10px 0}
 .cardSectionTitle{font-size:12px;font-weight:700;color:var(--muted);margin-bottom:8px}
 
-.compareCard{border:1px solid var(--stroke);border-radius:12px;background:#fff;padding:10px}
+.compareCard{border:1px solid var(--stroke);border-left:4px solid #9be8e4;border-radius:14px;background:#fff;padding:12px 12px 12px 14px;box-shadow:var(--shadow-sm)}
 .compareCard__title{font-weight:700;margin-bottom:6px}
 .compareCard__rows{display:grid;grid-template-columns:1fr auto;gap:6px 8px;font-size:13px}
 .compareCard__status{display:inline-flex;padding:4px 8px;border-radius:999px;font-weight:700;font-size:11px;margin-bottom:6px}
@@ -93,8 +96,8 @@ input,select{width:100%;padding:13px 12px;border:1px solid #c7d3e2;border-radius
 .statusLoss{background:#fee2e2;color:#991b1b}
 .elasticityMsg{margin:6px 0 0;color:#334155;font-weight:600}
 
-.stickyResultsCard{position:sticky;top:80px;align-self:start;max-height:calc(100vh - 96px);overflow:auto;box-shadow:var(--shadow-md)}
-.stickySummary{margin-top:10px;border:1px solid var(--stroke);border-radius:12px;padding:10px;background:#f8fbfd}
+.stickyResultsCard{position:sticky;top:80px;align-self:start;max-height:calc(100vh - 96px);overflow:auto;box-shadow:var(--shadow-sm)}
+.stickySummary{position:fixed;right:24px;bottom:24px;z-index:45;width:min(360px,calc(100vw - 32px));margin-top:0;border:1px solid var(--stroke);border-radius:16px;padding:14px;background:#fff;box-shadow:var(--shadow-md)}
 .stickySummary h3{margin:0 0 6px;font-size:16px}
 .stickySummary__content{font-size:13px;color:#334155}
 .stickySummary__actions{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:10px}
@@ -133,6 +136,7 @@ details p{margin:8px 0 0;color:#334155}
   .nav{display:none}
   .affGrid,.advGrid{grid-template-columns:1fr}
   .stickyResultsCard{position:static;max-height:none;overflow:visible}
+  .stickySummary{position:static;right:auto;bottom:auto;width:100%;margin-top:10px}
 }
 @media (max-width:720px){
   .segmentMenu{grid-template-columns:1fr 1fr}


### PR DESCRIPTION
### Motivation
- Modernize the application's UX/UI to a Light Pro (clean SaaS) theme with improved readability, spacing and hierarchy while preserving all calculation and JS behavior.

### Description
- Update the base design tokens and palette variables (`--bg`, `--surface`, `--surface-soft`, `--stroke`, `--text`, `--muted`, `--accent`, `--accent-soft`, `--shadow-*`, `--radius`) to the Light Pro palette.
- Refine global typography, spacing and rhythm (`body`, `hero`, section cards, labels, inputs) and increase generous paddings on cards and containers for better legibility.
- Restyle navigation, segmented menu and buttons with a white container, subtle shadows, rounded radii, accent primary state and smooth 0.2s transitions and hover microinteractions.
- Rework result and comparison cards for a cleaner visual hierarchy and add a floating sticky summary card (fixed bottom-right on desktop) with responsive fallback to static layout on small screens.
- Maintain strict constraints: only `assets/css/styles.css` was changed and no JavaScript, calculation rules, IDs/selectors, PDF generation, data structures or functional layout were altered.

### Testing
- Verified the CSS diff and inspected the updated file contents to ensure only presentation rules were changed and no selectors/IDs or JS hooks were modified.
- Launched a local static server with `python3 -m http.server --directory /workspace/calculadora` and validated served files were updated for manual review.
- Attempted an automated headless screenshot via Playwright to validate appearance, but the Chromium process crashed in this environment with a `SIGSEGV` error, so visual verification should be reviewed manually in a browser as needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f2fd2f1f4833294aa042f89bed5eb)