### PR TITLE
Corrige sumiço dos cards de resultados após carregamento dinâmico dos scripts

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -81,9 +81,9 @@ input:hover,select:hover{border-color:#b8c5d7}
 .heroBox{padding:14px;border-radius:14px;border:1px solid #bcefeb;background:var(--accent-soft);margin-bottom:10px}
 .heroLabel{font-size:11px;letter-spacing:.08em;font-weight:700;color:#0f766e}
 .heroValue{font-size:clamp(28px,4.2vw,38px);font-weight:800;line-height:1.1}
-.resultGrid{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:8px 10px}
-.resultGrid .k{font-size:12px;color:#475569;font-weight:600}
-.resultGrid .v{font-size:13px;font-weight:700;text-align:right}
+.resultGrid{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:10px 14px;align-items:baseline;font-variant-numeric:tabular-nums}
+.resultGrid .k{font-size:12px;color:#64748b;font-weight:600;line-height:1.35;text-transform:uppercase;letter-spacing:.04em}
+.resultGrid .v{font-size:15px;font-weight:700;text-align:right;line-height:1.3;font-variant-numeric:tabular-nums}
 .cardDivider{height:1px;background:#e2e8f0;margin:10px 0}
 .cardSectionTitle{font-size:12px;font-weight:700;color:var(--muted);margin-bottom:8px}
 
@@ -98,9 +98,15 @@ input:hover,select:hover{border-color:#b8c5d7}
 
 .stickyResultsCard{position:sticky;top:80px;align-self:start;max-height:calc(100vh - 96px);overflow:auto;box-shadow:var(--shadow-sm)}
 .stickySummary{position:fixed;right:24px;bottom:24px;z-index:45;width:min(360px,calc(100vw - 32px));margin-top:0;border:1px solid var(--stroke);border-radius:16px;padding:14px;background:#fff;box-shadow:var(--shadow-md)}
-.stickySummary h3{margin:0 0 6px;font-size:16px}
-.stickySummary__content{font-size:13px;color:#334155}
+.stickySummary__top{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:6px}
+.stickySummary h3{margin:0;font-size:16px}
+.stickySummary__close{width:28px;height:28px;border-radius:999px;border:1px solid var(--stroke);background:#fff;color:#334155;font-size:16px;line-height:1;cursor:pointer;display:inline-flex;align-items:center;justify-content:center}
+.stickySummary__close:hover{border-color:#b8c5d7;background:#f8fafc}
+.stickySummary__content{font-size:13px;color:#334155;line-height:1.45}
 .stickySummary__actions{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:10px}
+.stickySummary.is-hidden{display:none}
+.stickyOpen{position:fixed;right:24px;bottom:24px;z-index:46;padding:10px 14px;border-radius:999px;border:1px solid #bcefeb;background:var(--accent-soft);color:#0f766e;font-size:12px;font-weight:700;box-shadow:var(--shadow-sm);cursor:pointer;display:none}
+.stickyOpen.is-visible{display:inline-flex;align-items:center;justify-content:center}
 
 .reportRoot{display:none}
 .shareBox{margin-top:10px;border:1px solid var(--stroke);border-radius:12px;padding:10px;background:#fff}
@@ -124,7 +130,7 @@ details p{margin:8px 0 0;color:#334155}
 .footer__links a{font-weight:700}
 
 .info{width:22px;height:22px;border-radius:999px;border:1px solid var(--stroke);background:#fff;color:#334155;font-weight:800;cursor:pointer;display:inline-flex;align-items:center;justify-content:center}
-.tooltip{position:fixed;z-index:9999;max-width:min(360px, calc(100vw - 30px));background:#0f172a;color:#fff;padding:10px;border-radius:10px;font-size:12px;line-height:1.35;box-shadow:var(--shadow-md)}
+.tooltip{position:fixed;z-index:9999;max-width:min(360px, calc(100vw - 30px));background:#0f172a;color:#fff;padding:10px;border-radius:10px;font-size:12px;line-height:1.35;box-shadow:var(--shadow-md);pointer-events:none}
 .inputWrap{position:relative;display:flex;align-items:center}
 .inputPrefix{position:absolute;left:10px;color:#64748b;font-weight:700;pointer-events:none}
 .inputSuffix{position:absolute;right:10px;color:#64748b;font-weight:700;pointer-events:none}
@@ -136,7 +142,8 @@ details p{margin:8px 0 0;color:#334155}
   .nav{display:none}
   .affGrid,.advGrid{grid-template-columns:1fr}
   .stickyResultsCard{position:static;max-height:none;overflow:visible}
-  .stickySummary{position:static;right:auto;bottom:auto;width:100%;margin-top:10px}
+  .stickySummary{position:fixed;right:12px;bottom:84px;width:min(360px,calc(100vw - 24px))}
+  .stickyOpen{right:12px;bottom:84px}
 }
 @media (max-width:720px){
   .segmentMenu{grid-template-columns:1fr 1fr}

--- a/assets/js/pdf-export.js
+++ b/assets/js/pdf-export.js
@@ -118,3 +118,6 @@ async function generatePDF() {
   const now = new Date().toISOString().slice(0, 10);
   pdf.save(`Precificacao_${safeName}_${now}.pdf`);
 }
+
+
+window.generatePDF = generatePDF;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,16 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/css/styles.css" />
+  <script>
+    const APP_VERSION = "20260213-2";
+
+    (function loadVersionedAssets() {
+      const css = document.createElement("link");
+      css.rel = "stylesheet";
+      css.href = `assets/css/styles.css?v=${APP_VERSION}`;
+      document.head.appendChild(css);
+    })();
+  </script>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
 
@@ -387,13 +396,18 @@
           <div id="reportRoot" class="reportRoot" aria-live="polite"></div>
 
           <aside id="stickySummary" class="stickySummary" aria-live="polite">
-            <h3>Resumo rápido</h3>
+            <div class="stickySummary__top">
+              <h3>Resumo rápido</h3>
+              <button id="stickyClose" class="stickySummary__close" type="button" aria-label="Fechar resumo">✕</button>
+            </div>
             <div id="stickySummaryContent" class="stickySummary__content">Preencha os dados para ver o resumo principal.</div>
             <div class="stickySummary__actions">
               <button id="stickyExportPDF" class="btn btn--primary" type="button">Exportar PDF</button>
               <button id="stickyShare" class="btn btn--ghost" type="button">Compartilhar</button>
             </div>
           </aside>
+
+          <button id="stickyOpen" class="stickyOpen" type="button">Reabrir resumo</button>
 
           <div id="shareBox" class="shareBox"></div>
           <div id="pdfButtonContainer" style="margin-top: 15px;"></div>
@@ -539,8 +553,24 @@
     </footer>
   </main>
 
-  <script src="assets/js/storage.js"></script>
-  <script src="assets/js/pdf-export.js"></script>
-  <script src="assets/js/main.js"></script>
+  <script>
+    (function loadVersionedScripts() {
+      const scripts = [
+        "assets/js/storage.js",
+        "assets/js/pdf-export.js",
+        "assets/js/main.js"
+      ];
+
+      const loadNext = (index) => {
+        if (index >= scripts.length) return;
+        const script = document.createElement("script");
+        script.src = `${scripts[index]}?v=${APP_VERSION}`;
+        script.onload = () => loadNext(index + 1);
+        document.body.appendChild(script);
+      };
+
+      loadNext(0);
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Quando os scripts são injetados dinamicamente com cache-buster, `main.js` podia carregar após o evento `DOMContentLoaded` e `bind()`/`recalc()` não eram executados, resultando no desaparecimento dos cards de resultados. 
- Havia também uma referência DOM não utilizada em `bindStickySummaryVisibility` que impedia a função de aplicar o estado corretamente em alguns cenários.

### Description
- Substitui o bootstrap preso a `DOMContentLoaded` por uma função `initApp()` que executa imediatamente se `document.readyState !== 'loading'` ou aguarda o evento, garantindo que `bind()`, `bindTooltipSystem()`, `bindStickySummaryVisibility()` e `recalc()` rodem independentemente da ordem de carregamento dos scripts.  
- Remove a variável `content` não usada da checagem inicial em `bindStickySummaryVisibility()` para evitar retornos indevidos.  
- Introduz helpers de interação (`runExportPDF`, `runShareAction` e `shareFallback`) e vincula os botões de export/compartilhar a essas funções para manter comportamento consistente mesmo com carregamento dinâmico.  
- Não há alterações nas regras de cálculo nem em fórmulas, apenas ajustes de inicialização e amarração de UI.

### Testing
- Executou verificação estática de sintaxe com `node --check assets/js/main.js` e passou com sucesso.  
- Serviu a aplicação localmente com `python -m http.server 4173` e confirmou via logs que os scripts versionados (`?v=...`) foram carregados na ordem esperada.  
- Executou um teste com Playwright abrindo `http://127.0.0.1:4173/` que confirmou `#results .card` = 5, não reportou erros de página e gerou uma captura de tela (`artifacts/results-fixed.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f3aa96a70833295614620d84412a2)