### PR TITLE
Add GA4 (G-7RHBD29L5S) and strategic tracking events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Calculadora de Precificação
+
+## Google Analytics 4 (GA4)
+
+- **Measurement ID (GA4):** `G-7RHBD29L5S`
+
+## Eventos implementados
+
+- `usuario_engajado`
+- `perfil_ticket`
+- `export_pdf`
+- `cta_click`
+
+## Como configurar Key events no GA4
+
+1. Acesse **Administrador** no GA4.
+2. Em **Eventos**, localize os eventos:
+   - `export_pdf`
+   - `cta_click`
+3. Marque cada um como **Key event** (evento principal).
+
+## Como criar dimensões personalizadas no GA4
+
+Acesse **Administrador → Definições personalizadas → Criar dimensão personalizada** e crie:
+
+1. **Faixa de ticket**
+   - Escopo: **Evento**
+   - Parâmetro do evento: `faixa`
+
+2. **Preço sugerido**
+   - Escopo: **Evento**
+   - Parâmetro do evento: `preco_sugerido`

--- a/index.html
+++ b/index.html
@@ -24,13 +24,16 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
 
-  <!-- Google tag (gtag.js) -->
+  <!-- Google Analytics 4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7RHBD29L5S"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'G-7RHBD29L5S');
+    gtag('config', 'G-7RHBD29L5S', {
+      send_page_view: true,
+      anonymize_ip: true
+    });
   </script>
 </head>
 


### PR DESCRIPTION
### Motivation
- Install Google Analytics 4 and add strategic events to enable product analytics for the pricing calculator without changing any calculation logic or UX.
- Capture user engagement, ticket profile, PDF exports and CTA clicks to allow analysis and custom dimensions in GA4.

### Description
- Add GA4 snippet to `index.html` with `G-7RHBD29L5S` and options `send_page_view: true` and `anonymize_ip: true`.
- Add global helpers in `assets/js/main.js`: `track(eventName, params = {})` and `setUserProperty(name, value)` with safe guards when `gtag` is not present.
- Implement `usuario_engajado` via `trackEngaged()` with a session-level lock (`__engaged`) and hook it to first meaningful `input`/`change` on relevant fields so it fires only once per session.
- Implement `perfil_ticket` with `ticketFaixa(v)`, anti-flood by last faixa (`__lastFaixa`), event parameters `faixa` and `preco_sugerido`, and set user property `perfil_ticket`; call `trackPerfilTicket(shopee.price)` after the main `recalc` results are rendered.
- Ensure `export_pdf` event is fired on PDF generation with a `device` parameter (`mobile`/`desktop`) and that `cta_click` events for Instagram/WhatsApp include `cta` and `destino` (the link) to avoid duplicate or missing context.
- Update `README.md` documenting the GA4 Measurement ID, implemented events, instructions to mark `export_pdf` and `cta_click` as key events in GA4, and instructions to create custom dimensions `faixa` and `preco_sugerido`.

### Testing
- Ran `node --check assets/js/main.js` to validate the modified JS syntax, which completed without errors.
- Ran a search for the new GA4 identifiers and event symbols with `rg` which confirmed the expected strings are present in `index.html`, `assets/js/main.js` and `README.md`.
- No changes were made to calculation logic and no runtime changes to UI were introduced; unit/functional tests were not present in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f4bc22cec83329dd162e44ca1c453)