### PR TITLE
Refina alinhamento visual dos cards de resultados

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -81,13 +81,63 @@ input:hover,select:hover{border-color:#b8c5d7}
 .affGrid{display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px;margin-top:10px}
 
 .resultList,.marketCompareList{display:flex;flex-direction:column;gap:12px}
+.resultList .card,
+.marketCompareList .card{
+  padding-right:2px;
+}
+.cardHeader{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:10px;
+  margin-bottom:10px;
+}
+.cardTitle{
+  flex:1 1 auto;
+  min-width:0;
+  font-size:15px;
+  line-height:1.3;
+  font-weight:700;
+  letter-spacing:-.01em;
+}
+.cardHeader .pill{
+  flex:0 0 auto;
+  white-space:nowrap;
+}
 .heroBox{padding:14px;border-radius:14px;border:1px solid #bcefeb;background:var(--accent-soft);margin-bottom:10px}
 .heroLabel{font-size:11px;letter-spacing:.08em;font-weight:700;color:#0f766e}
 .heroValue{font-size:clamp(28px,4.2vw,38px);font-weight:800;line-height:1.1}
-.resultGrid{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:10px 14px;align-items:baseline;font-variant-numeric:tabular-nums}
-.resultGrid .k{font-size:12px;color:#64748b;font-weight:600;line-height:1.35;text-transform:uppercase;letter-spacing:.04em}
-.resultGrid .v{font-size:15px;font-weight:700;text-align:right;line-height:1.3;font-variant-numeric:tabular-nums}
-.cardDivider{height:1px;background:#e2e8f0;margin:10px 0}
+.resultGrid{
+  display:grid;
+  grid-template-columns:1fr auto;
+  gap:8px;
+  align-items:baseline;
+  font-variant-numeric:tabular-nums;
+  font-feature-settings:"tnum" 1,"lnum" 1;
+}
+.resultGrid .k{
+  font-size:11px;
+  color:var(--muted);
+  font-weight:600;
+  line-height:1.3;
+  text-transform:uppercase;
+  letter-spacing:.04em;
+}
+.resultGrid .v{
+  font-size:14px;
+  font-weight:600;
+  color:var(--text);
+  text-align:right;
+  line-height:1.3;
+  white-space:nowrap;
+  font-variant-numeric:tabular-nums;
+  font-feature-settings:"tnum" 1,"lnum" 1;
+}
+.resultGrid--details .k,
+.resultGrid--details .v{
+  line-height:1.35;
+}
+.cardDivider{height:1px;background:var(--stroke);margin:12px 0}
 .cardSectionTitle{font-size:12px;font-weight:700;color:var(--muted);margin-bottom:8px}
 
 .compareCard{border:1px solid var(--stroke);border-left:4px solid #9be8e4;border-radius:14px;background:#fff;padding:12px 12px 12px 14px;box-shadow:var(--shadow-sm)}
@@ -164,8 +214,10 @@ details p{margin:8px 0 0;color:#334155}
   .sectionCard{padding:16px}
   .grid,.row2,.affGrid,.advGrid,.stickySummary__actions,.shareBox__actions,.actions{grid-template-columns:1fr}
   .card__inner{padding:16px}
+  .cardHeader{flex-wrap:wrap}
+  .cardHeader .pill{margin-top:2px}
   .resultGrid .k{font-size:11px}
-  .resultGrid .v{font-size:14px;max-width:52vw;overflow-wrap:anywhere}
+  .resultGrid .v{font-size:13px}
   .stickySummary{left:10px;right:10px;bottom:74px;width:auto;max-height:70vh;overflow:hidden;padding:12px;border-radius:14px}
   .stickySummary__content{max-height:42vh;overflow:auto;padding-right:4px}
   .stickyOpen{right:10px;bottom:18px}


### PR DESCRIPTION
### Motivation
- Corrigir desalinhamento e inconsistência tipográfica nas linhas de resumo (VOCÊ RECEBE / LUCRO / TOTAL) dos cards de marketplace para garantir uma coluna de valores uniforme à direita.
- Garantir que o detalhamento das incidências (chave/valor) siga o mesmo padrão de alinhamento e tipografia do resumo.
- Manter o visual existente (“Light Pro”) sem alterar lógica, cálculos ou o HTML gerado.

### Description
- Atualiza apenas `assets/css/styles.css` adicionando `.cardHeader`, `.cardTitle` e regras para `.cardHeader .pill` para controlar alinhamento e quebra do título/pill em uma linha única quando possível.
- Padroniza o resumo e o detalhamento com `.resultGrid { grid-template-columns: 1fr auto; gap: 8px; }` e aplica `text-align: right` / `white-space: nowrap` nos valores.
- Aplica números tabulares com `font-variant-numeric: tabular-nums;` e `font-feature-settings: "tnum" 1, "lnum" 1;` nos blocos de valor e refina tamanhos/pesos/cor para labels (`.k`) e valores (`.v`) para hierarquia consistente.
- Ajusta divisor (`.cardDivider`) para usar `var(--stroke)` e margem suave, adiciona `padding-right` mínimo nas cards dentro de listas para mitigar scrollbar interna e adiciona regras responsivas (`.cardHeader{flex-wrap:wrap}` e ajuste de `font-size` em mobile).
- Alterações limitadas ao CSS; não há mudanças em HTML/JS nem em cálculo de valores.

### Testing
- Executado `git diff -- assets/css/styles.css` para revisar alterações no arquivo e `git commit` realizado com sucesso.
- Servido localmente com `python3 -m http.server 4173` para validar visual manualmente, sem erro no servidor.
- Renderização automatizada via Playwright (Firefox) executou com sucesso e gerou screenshot de verificação (artifact disponível).
- Tentativa de renderização via Playwright (Chromium) falhou devido a crash do browser no ambiente (SIGSEGV), mas não impactou as alterações de CSS nem os testes bem-sucedidos com Firefox.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f50446a488332983e4b8d38a822dd)