### PR TITLE
Refatora exportação de PDF para fluxo nativo de impressão

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -36,6 +36,7 @@ a{color:inherit;text-decoration:none}
 .btn--primary:hover{background:#0b9a99;border-color:#0b9a99}
 .btn--ghost{background:#fff;color:#0f172a}
 .btn--wide{width:100%;padding:14px}
+.btn.is-loading{opacity:.75;cursor:wait;pointer-events:none}
 
 .hero{padding:36px 0 24px}
 .kicker{display:inline-flex;padding:7px 11px;border-radius:999px;background:var(--accent-soft);color:var(--accent);font-weight:700;font-size:12px}

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/styles.css" data-asset="true" />
   <script>
-    const APP_VERSION = "20260213-1530";
+    const APP_VERSION = "20260213-2";
 
     window.versionAssetPath = function versionAssetPath(path) {
       const url = new URL(path, window.location.href);
@@ -30,8 +30,6 @@
       });
     })();
   </script>
-
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
 
   <!-- Google Analytics 4 -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7RHBD29L5S"></script>


### PR DESCRIPTION
### Motivation
- Eliminar a dependência de captura em canvas (`html2canvas` / `html2pdf` / `jsPDF`) que causava o erro "html2canvas is not defined" e impedia os botões de exportar funcionarem.
- Simplificar e tornar mais confiável a experiência de exportação usando capacidades nativas do navegador (abrir janela + `window.print()`).
- Melhorar a UX durante geração do relatório exibindo estado de loading e evitando múltiplas ações concorrentes.

### Description
- Substitui a implementação antiga em `assets/js/pdf-export.js` por um novo fluxo que monta HTML limpo do relatório (`collectReportItems`, `buildPrintHTML`, `escapeHTML`) e usa `window.open()` + `print()` + fechamento automático da janela após impressão.
- Removei toda a lógica de captura em canvas / watermark / jsPDF e dependências relacionadas do arquivo `pdf-export.js` e deixei `window.generatePDF` apontando para a nova função.
- Tornei `runExportPDF` assíncrona em `assets/js/main.js`, adicionei passagem opcional do botão disparador para controlar estado (desabilitar, `is-loading`, `aria-busy`) e atualizei o handler de ação para `await runExportPDF(...)`.
- Atualizei `index.html` para remover o CDN de `html2pdf` e atualizei `APP_VERSION` para `20260213-2` para versionamento automático dos assets, e adicionei `assets/css/styles.css` uma classe `.btn.is-loading` para feedback visual.

### Testing
- Executei verificação de sintaxe com `node --check assets/js/main.js && node --check assets/js/pdf-export.js` e ambos passaram com sucesso.
- Verifiquei que não há menções a `html2canvas|jspdf|html2pdf|canvas` em `index.html`, `assets/js` e `assets/css` usando `rg`, sem ocorrências encontradas.
- Rodei um teste E2E local com servidor HTTP e Playwright (com stub de `window.open/print`) que simulou cálculo + clique em exportar e retornou `NO_CONSOLE_ERRORS`, gerando screenshot em `artifacts/pdf-export-new-flow.png` como evidência visual.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f596e97f483329bfcaf6f48bb27d2)