### PR TITLE
feat: plataforma estratégica de decisão v2.0 para precificação

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -98,7 +98,8 @@ input:hover,select:hover{border-color:#b8c5d7}
   min-width:0;
   font-size:17px;
   line-height:1.25;
-  font-weight:800;
+  font-weight:700;
+  text-transform:uppercase;
   letter-spacing:-.01em;
   color:#0b2239;
 }
@@ -217,6 +218,35 @@ details p{margin:8px 0 0;color:#334155}
 .inputSuffix{position:absolute;right:10px;color:#64748b;font-weight:700;pointer-events:none}
 .inputWrap input{padding-left:36px}
 .inputWrap .inputSuffix + input,.inputWrap input + .inputSuffix{padding-right:36px;padding-left:12px}
+
+
+body.theme-dark{--bg:#0f172a;--surface:#1e293b;--surface-soft:#1f2d46;--stroke:#334155;--text:#e2e8f0;--muted:#94a3b8;--accent:#14b8a6;--accent-soft:#173f42}
+body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.theme-dark .card,body.theme-dark .sectionCard,body.theme-dark .hint,body.theme-dark .shareBox{background:#1e293b;color:#e2e8f0}
+
+.rankingInsights{margin:0 0 12px;padding:12px;border:1px solid var(--stroke);border-radius:12px;background:var(--surface-soft);display:grid;gap:6px}
+.actions--stacked{margin-top:10px;display:grid;grid-template-columns:1fr;gap:8px}
+
+.marketplaceCard .cardHeader{padding:14px 16px;margin:-1px -1px 10px;border-radius:16px 16px 0 0;border-bottom:1px solid var(--stroke)}
+.marketplaceCard.marketplace-shopee .cardHeader{background:rgba(238,77,45,.08)}
+.marketplaceCard.marketplace-tiktok .cardHeader{background:rgba(0,0,0,.06)}
+.marketplaceCard.marketplace-ml .cardHeader{background:rgba(255,221,0,.15)}
+.marketplaceCard.marketplace-shein .cardHeader{background:rgba(30,64,175,.10)}
+
+.heroBox{padding:20px 16px;margin-bottom:16px}
+.heroLabel{font-size:11px;letter-spacing:.14em}
+.heroValue{font-size:clamp(32px,4vw,44px);font-weight:800}
+.heroBox::after{content:"";display:block;height:1px;background:#9bd9d3;margin-top:12px}
+
+.resultGrid{display:grid;grid-template-columns:1fr auto;gap:8px 10px}
+.resultGrid .k{font-weight:500}
+.resultGrid .v{text-align:right;font-weight:700}
+
+@media (max-width:768px){
+  .resultList .card,.marketCompareList .card{overflow:visible}
+  .cardTitle{font-size:15px}
+  .heroValue{font-size:30px}
+  .btn{width:100%}
+}
 
 @media (max-width:980px){
   .grid{grid-template-columns:1fr}

--- a/assets/js/pdf-export.js
+++ b/assets/js/pdf-export.js
@@ -91,9 +91,10 @@ function getReportMarkup() {
 
   return `
     <section class="print-report">
-      <h1>Relatório de Precificação</h1>
+      <h1>Relatório Estratégico de Precificação</h1>
       <div class="date">Gerado em ${escapeHTML(dateTime)}</div>
-      ${buildReportCardsHTML(items)}
+      <div class="meta">Produto: <strong>${escapeHTML(items[0]?.calcName || "Cálculo sem nome")}</strong></div>${buildReportCardsHTML(items)}
+      <footer style="margin-top:16px;font-size:12px;color:#475569">Rafa Maceno • <a href="https://www.instagram.com/macenorafa/" target="_blank" rel="noopener">Instagram</a></footer>
     </section>
   `;
 }

--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/css/styles.css?v=20260213-4" data-asset="true" />
+  <link rel="stylesheet" href="assets/css/styles.css?v=20260213-5" data-asset="true" />
   <script>
-    const APP_VERSION = "20260213-4";
+    const APP_VERSION = "20260213-5";
 
     window.versionAssetPath = function versionAssetPath(path) {
       const url = new URL(path, window.location.href);
@@ -67,6 +67,7 @@
       </nav>
 
       <div class="topbar__cta">
+        <button id="themeToggle" class="btn btn--ghost" type="button" aria-label="Alternar tema">🌓 Tema</button>
         <a class="btn btn--ghost js-cta-instagram" data-action="cta-instagram" href="https://www.instagram.com/macenorafa/" target="_blank" rel="noopener">Seguir no Instagram</a>
         <a class="btn btn--primary js-cta-whatsapp" data-action="cta-whatsapp-community" href="https://chat.whatsapp.com/Ff9jaV8Lj1K4Qm2bNNIQdy" target="_blank" rel="noopener">Entrar na Comunidade WhatsApp</a>
       </div>
@@ -401,19 +402,27 @@
           </div>
 
           <button id="recalc" class="btn btn--primary btn--wide" type="button">Recalcular</button>
+
+          <div class="actions actions--stacked">
+            <button id="saveSimulation" class="btn btn--ghost btn--wide" type="button">Salvar Simulação</button>
+            <select id="savedSimulations" aria-label="Simulações salvas">
+              <option value="">Simulações salvas</option>
+            </select>
+          </div>
         </div>
       </div>
 
       <div class="card stickyResultsCard">
         <div class="card__inner">
           <h2>Resultados</h2>
+          <div id="rankingInsights" class="rankingInsights" aria-live="polite"></div>
           <div id="results" class="resultList"></div>
 
           <div id="reportRoot" class="reportRoot" aria-live="polite"></div>
 
           <aside id="stickySummary" class="stickySummary" aria-live="polite">
             <div class="stickySummary__top">
-              <h3>Resumo rápido</h3>
+              <h3>Resumo Estratégico</h3>
               <button id="stickyClose" class="stickySummary__close" type="button" aria-label="Fechar resumo">✕</button>
             </div>
             <div id="stickySummaryContent" class="stickySummary__content">Preencha os dados para ver o resumo principal.</div>
@@ -486,43 +495,17 @@
     </section>
 
     <section id="sec-escala" class="sectionCard">
-      <h2>Escala</h2>
-      <p class="sectionMicrocopy">Compare dois cenários de preço x volume e veja qual coloca mais dinheiro no bolso.</p>
+      <h2>Simulação de Escala</h2>
+      <p class="sectionMicrocopy">Defina o volume de vendas e veja o lucro total em cada marketplace.</p>
       <div class="card card--simple">
         <div class="card__inner">
           <div class="cardMini quickMode">
             <div class="cardMini__header">
-              <strong>Simulador de escala</strong>
+              <strong>Simulação de Escala</strong>
             </div>
             <div class="field">
-              <div class="label">Marketplace base para o simulador</div>
-              <select id="scaleMarketplace">
-                <option value="shopee">Shopee</option>
-                <option value="tiktok">TikTok Shop</option>
-                <option value="shein">SHEIN</option>
-                <option value="mlClassic">Mercado Livre — Clássico</option>
-                <option value="mlPremium">Mercado Livre — Premium</option>
-              </select>
-            </div>
-            <div class="row2">
-              <div class="field">
-                <div class="label">Cenário A: Preço (R$)</div>
-                <input id="scalePriceA" type="number" step="0.01" min="0" placeholder="Ex: 109,90" />
-              </div>
-              <div class="field">
-                <div class="label">Cenário A: Unidades</div>
-                <input id="scaleUnitsA" type="number" step="1" min="0" placeholder="Ex: 100" />
-              </div>
-            </div>
-            <div class="row2">
-              <div class="field">
-                <div class="label">Cenário B: Preço (R$)</div>
-                <input id="scalePriceB" type="number" step="0.01" min="0" placeholder="Ex: 99,90" />
-              </div>
-              <div class="field">
-                <div class="label">Cenário B: Unidades</div>
-                <input id="scaleUnitsB" type="number" step="1" min="0" placeholder="Ex: 140" />
-              </div>
+              <div class="label">Quantidade de vendas</div>
+              <input id="scaleSalesQty" type="number" step="1" min="0" placeholder="Ex: 100" />
             </div>
             <div id="scaleResults" class="marketCompareList"></div>
           </div>
@@ -574,9 +557,9 @@
   <script>
     (function loadVersionedScripts() {
       const scripts = [
-        "assets/js/storage.js?v=20260213-4",
-        "assets/js/pdf-export.js?v=20260213-4",
-        "assets/js/main.js?v=20260213-4"
+        "assets/js/storage.js?v=20260213-5",
+        "assets/js/pdf-export.js?v=20260213-5",
+        "assets/js/main.js?v=20260213-5"
       ];
 
       const loadNext = (index) => {


### PR DESCRIPTION
### Motivation
- Evoluir a calculadora atual para uma Plataforma Estratégica de Decisão (v2.0) com camadas de UX/UI, analytics e exportação, sem mexer nas fórmulas de cálculo existentes.
- Adicionar visões estratégicas (ranking, resumo estratégico), simulação de escala por volume, persistência de cenários e compartilhamento via URL para facilitar decisões operacionais.

### Description
- UI/UX: reforcei os cards de marketplace (header tonalizado por marca, título em CAIXA ALTA, `PREÇO IDEAL`, maior hierarquia visual), alinhei campos com `display:grid` e weights de label/valor atualizados e adicionei botão de toggle Light/Dark com persistência (`THEME_KEY`).
- Estratégia e features: implementei ranking automático (`renderRankingInsights`), resumo estratégico com comparação 1º vs 2º e indicador visual, simulação de escala por quantidade (`scaleSalesQty`) que calcula lucro total por marketplace, e botões/dropdown para `Salvar Simulação` em `localStorage` (`SAVED_SIMULATIONS_KEY`) com carregamento posterior.
- Compartilhamento/URL: criei link simples com query params `?custo=&imposto=&lucro=` e leitura automática ao carregar (`applySimpleShareParams`), além de manter o estado compartilhável existente quando aplicável.
- Exportação PDF/Impressão: reescrevi o relatório impresso para usar `window.print()` (modo impressão), acrescentei título "Relatório Estratégico de Precificação", data, produto e rodapé com crédito/Instagram, removendo dependência de técnicas de captura (não usa html2canvas).
- Analytics: adicionei/ajustei eventos GA4 solicitados (`calculate_clicked`, `export_pdf`, `share_clicked`, `scale_simulation_used`, `simulation_saved`, `marketplace_rank_generated`) mantendo tracking pré-existente via `gtag`.
- Assets e styles: atualizei versionamento de assets para `20260213-5` em `index.html`, adicionei CSS para `theme-dark`, estilos de cabeçalho por marketplace, maior destaque para `heroValue` e ajuste da grade interna dos cards.
- Arquivos modificados principais: `index.html` (UI + asset version), `assets/js/main.js` (lógicas novas: ranking, persistência, compartilhamento, tema, simulação de escala), `assets/css/styles.css` (novos estilos + dark theme), `assets/js/pdf-export.js` (texto/rodapé do relatório).

### Testing
- `node --check assets/js/main.js` — passou com sucesso.
- `node --check assets/js/pdf-export.js` — passou com sucesso.
- `node --check assets/js/storage.js` — passou com sucesso.
- Servidor local e validação visual: `python3 -m http.server 4173` + navegação automática e screenshot via Playwright, página carregou e screenshot foi gerada (visual smoke test OK).
- Linter/syntax checks e carga dos scripts via versão (`APP_VERSION=20260213-5`) validados runtime simples; todos os testes automáticos acima concluíram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f678f67c08332b6622257aec14df1)