### PR TITLE
feat: UX revamp — CTAs, marketplace cards, incidences accordion, PDF, YouTube rail & especialista page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -299,3 +299,33 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
   .btn{padding:11px 12px;font-size:14px}
   .stickyOpen{padding:10px 12px}
 }
+
+.btn--cta{min-height:46px;padding:12px 18px;border-radius:12px}
+.btn--outline{background:transparent;color:#0f172a;border:1px solid #0f172a}
+.btn--outline:hover{background:#0f172a;color:#fff;border-color:#0f172a}
+.segmentMenu__btn.is-active{background:var(--accent);color:#fff;border-color:var(--accent);box-shadow:var(--shadow-sm)}
+
+.cardTitleWrap{display:flex;align-items:center;gap:10px;min-width:0}
+.cardIcon{display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;border-radius:10px;background:#fff;border:1px solid var(--stroke);font-size:16px}
+
+.resultGrid .v .incidenceToggle{margin:0 0 0 auto}
+.incidenceToggle{display:inline-flex;align-items:center;justify-content:space-between;gap:8px;padding:8px 10px;border:1px solid var(--stroke);border-radius:10px;background:#fff;font-weight:700;color:#0f172a;cursor:pointer;min-height:auto}
+.incidenceToggle__icon{transition:transform .25s ease}
+.incidenceToggle[aria-expanded="true"] .incidenceToggle__icon{transform:rotate(180deg)}
+.incidencePanel{max-height:0;overflow:hidden;transition:max-height .28s ease,opacity .28s ease;opacity:0}
+.incidencePanel.is-open{max-height:480px;opacity:1;margin-top:10px;padding-top:10px;border-top:1px solid var(--stroke)}
+
+.sectionCard--youtube{background:linear-gradient(180deg,#f8fbff,#f2f8ff)}
+.youtubeRail{display:flex;gap:12px;overflow-x:auto;padding-bottom:8px;scroll-snap-type:x proximity}
+.youtubeCard{flex:0 0 min(280px,80vw);display:flex;flex-direction:column;gap:8px;background:#fff;border:1px solid var(--stroke);border-radius:14px;padding:10px;box-shadow:var(--shadow-sm);scroll-snap-align:start}
+.youtubeCard img{width:100%;height:150px;object-fit:cover;border-radius:10px}
+.youtubeCard span{font-weight:600;color:#0f172a;line-height:1.3}
+
+.strategicCta{text-align:center;padding:34px 24px}
+.strategicCta p{margin:10px auto 18px;max-width:60ch;color:var(--muted)}
+.strategicCta .btn{max-width:320px;width:100%}
+
+@media (max-width:768px){
+  .topbar .nav .btn--cta{width:100%}
+  .incidenceToggle{width:100%;justify-content:space-between}
+}

--- a/hora-com-o-especialista.html
+++ b/hora-com-o-especialista.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>A Hora com o Especialista | Precificação Marketplaces</title>
+  <meta name="description" content="Análise estratégica da sua conta para escalar com margem, previsibilidade e plano de ação." />
+  <link rel="stylesheet" href="assets/css/styles.css?v=20260213-4" />
+
+  <!-- Google Analytics 4 -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-7RHBD29L5S"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);} 
+    gtag('js', new Date());
+    gtag('config', 'G-7RHBD29L5S', { send_page_view: true, anonymize_ip: true });
+  </script>
+</head>
+<body>
+  <main class="container" style="padding:34px 0 46px;">
+    <section class="sectionCard" style="text-align:center;">
+      <span class="kicker">Atendimento estratégico</span>
+      <h1 style="margin:12px 0 8px;font-size:clamp(30px,5vw,46px);">A Hora com o Especialista</h1>
+      <p style="margin:0 auto;max-width:66ch;color:var(--muted);">Uma análise estratégica da sua conta com direcionamento claro para escalar.</p>
+    </section>
+
+    <section class="sectionCard">
+      <h2>O que você recebe</h2>
+      <ul>
+        <li>Análise completa da sua conta</li>
+        <li>Diagnóstico de margem</li>
+        <li>Revisão de anúncios</li>
+        <li>Mini mentoria personalizada</li>
+        <li>Resolução de dúvidas ao vivo</li>
+      </ul>
+    </section>
+
+    <section class="sectionCard">
+      <h2>Para quem é</h2>
+      <ul>
+        <li>Vendedores travados</li>
+        <li>Quem não entende margem real</li>
+        <li>Quem quer escalar com segurança</li>
+      </ul>
+    </section>
+
+    <section class="sectionCard">
+      <h2>Como funciona</h2>
+      <ol>
+        <li>Você agenda</li>
+        <li>Envia dados</li>
+        <li>Recebe análise ao vivo</li>
+        <li>Sai com plano de ação</li>
+      </ol>
+    </section>
+
+    <section class="sectionCard">
+      <h2>Antes e depois da análise</h2>
+      <div class="grid" style="grid-template-columns:1fr 1fr;">
+        <div class="card"><div class="card__inner"><h3 style="margin-top:0;">Antes</h3><p>Preço no escuro, margem confusa, decisões por tentativa e erro.</p></div></div>
+        <div class="card"><div class="card__inner"><h3 style="margin-top:0;">Depois</h3><p>Plano claro, margem estruturada e prioridades práticas para escalar.</p></div></div>
+      </div>
+    </section>
+
+    <section class="sectionCard" style="text-align:center;">
+      <h2>Investimento</h2>
+      <p style="font-size:36px;font-weight:800;margin:8px 0 16px;">R$ 497</p>
+      <a class="btn btn--primary" href="#" data-action="cta-specialist" data-from="hora-page" style="max-width:340px;width:100%;">Quero agendar minha hora</a>
+      <p class="sectionMicrocopy" style="margin-top:10px;">Página preparada para futura integração com pagamento.</p>
+    </section>
+
+    <p style="text-align:center;"><a href="index.html">← Voltar para a calculadora</a></p>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/css/styles.css?v=20260213-5" data-asset="true" />
+  <link rel="stylesheet" href="assets/css/styles.css?v=20260213-4" data-asset="true" />
   <script>
-    const APP_VERSION = "20260213-5";
+    const APP_VERSION = "20260213-4";
 
     window.versionAssetPath = function versionAssetPath(path) {
       const url = new URL(path, window.location.href);
@@ -60,16 +60,18 @@
       </button>
 
       <nav id="topbarNav" class="nav" aria-label="Navegação">
-        <a href="#sec-precificacao">Calculadora</a>
+        <a href="#precificacao">Calculadora</a>
         <a href="#faq">FAQ</a>
-        <a class="btn btn--primary js-cta-whatsapp" data-action="cta-whatsapp-community" href="https://chat.whatsapp.com/Ff9jaV8Lj1K4Qm2bNNIQdy" target="_blank" rel="noopener">Entrar na Comunidade WhatsApp</a>
-        <a class="btn btn--ghost js-cta-instagram" data-action="cta-instagram" href="https://www.instagram.com/macenorafa/" target="_blank" rel="noopener">Seguir no Instagram</a>
+        <a class="btn btn--primary btn--cta js-cta-whatsapp" data-action="cta-whatsapp-community" href="https://chat.whatsapp.com/Ff9jaV8Lj1K4Qm2bNNIQdy" target="_blank" rel="noopener">Entrar na Comunidade WhatsApp</a>
+        <a class="btn btn--outline btn--cta" href="hora-com-o-especialista.html">A Hora com o Especialista</a>
+        <a class="btn btn--ghost btn--cta js-cta-instagram" data-action="cta-instagram" href="https://www.instagram.com/macenorafa/" target="_blank" rel="noopener">Seguir no Instagram</a>
       </nav>
 
       <div class="topbar__cta">
         <button id="themeToggle" class="btn btn--ghost" type="button" aria-label="Alternar tema">🌓 Tema</button>
-        <a class="btn btn--ghost js-cta-instagram" data-action="cta-instagram" href="https://www.instagram.com/macenorafa/" target="_blank" rel="noopener">Seguir no Instagram</a>
-        <a class="btn btn--primary js-cta-whatsapp" data-action="cta-whatsapp-community" href="https://chat.whatsapp.com/Ff9jaV8Lj1K4Qm2bNNIQdy" target="_blank" rel="noopener">Entrar na Comunidade WhatsApp</a>
+        <a class="btn btn--primary btn--cta js-cta-whatsapp" data-action="cta-whatsapp-community" href="https://chat.whatsapp.com/Ff9jaV8Lj1K4Qm2bNNIQdy" target="_blank" rel="noopener">Entrar na Comunidade WhatsApp</a>
+        <a class="btn btn--outline btn--cta" href="hora-com-o-especialista.html">A Hora com o Especialista</a>
+        <a class="btn btn--ghost btn--cta js-cta-instagram" data-action="cta-instagram" href="https://www.instagram.com/macenorafa/" target="_blank" rel="noopener">Seguir no Instagram</a>
       </div>
     </div>
   </header>
@@ -83,13 +85,13 @@
     </section>
 
     <nav class="segmentMenu" aria-label="Menu de blocos">
-      <button class="segmentMenu__btn" type="button" data-scroll-target="sec-precificacao">Precificação</button>
-      <button class="segmentMenu__btn" type="button" data-scroll-target="sec-comparar">Comparar preço</button>
-      <button class="segmentMenu__btn" type="button" data-scroll-target="sec-lucro-atual">Lucro atual</button>
-      <button class="segmentMenu__btn" type="button" data-scroll-target="sec-escala">Escala</button>
+      <button class="segmentMenu__btn is-active" type="button" data-scroll-target="precificacao">Precificação</button>
+      <button class="segmentMenu__btn" type="button" data-scroll-target="comparar">Comparar preço</button>
+      <button class="segmentMenu__btn" type="button" data-scroll-target="lucro">Lucro atual</button>
+      <button class="segmentMenu__btn" type="button" data-scroll-target="escala">Escala</button>
     </nav>
 
-    <section id="sec-precificacao" class="sectionCard">
+    <section id="precificacao" class="sectionCard">
       <h2>Precificação</h2>
       <p class="sectionMicrocopy">Preencha seus custos e veja o preço sugerido com lucro real.</p>
       <div class="grid">
@@ -450,7 +452,7 @@
       </div>
     </section>
 
-    <section id="sec-comparar" class="sectionCard">
+    <section id="comparar" class="sectionCard">
       <h2>Comparar preço</h2>
       <p class="sectionMicrocopy">Digite um preço de venda e compare o lucro/prejuízo em cada marketplace.</p>
       <div class="card card--simple">
@@ -472,7 +474,7 @@
       </div>
     </section>
 
-    <section id="sec-lucro-atual" class="sectionCard">
+    <section id="lucro" class="sectionCard">
       <h2>Lucro atual</h2>
       <p class="sectionMicrocopy">Digite o preço que você pratica hoje e descubra sua margem real.</p>
       <div class="card card--simple">
@@ -494,7 +496,7 @@
       </div>
     </section>
 
-    <section id="sec-escala" class="sectionCard">
+    <section id="escala" class="sectionCard">
       <h2>Simulação de Escala</h2>
       <p class="sectionMicrocopy">Defina o volume de vendas e veja o lucro total em cada marketplace.</p>
       <div class="card card--simple">
@@ -511,6 +513,19 @@
           </div>
         </div>
       </div>
+    </section>
+
+
+    <section id="youtube" class="sectionCard sectionCard--youtube">
+      <h2>Últimos vídeos sobre Marketplace</h2>
+      <p class="sectionMicrocopy">Aprenda estratégias práticas de precificação, margem e escala.</p>
+      <div id="youtubeRail" class="youtubeRail" aria-live="polite"></div>
+    </section>
+
+    <section class="sectionCard strategicCta">
+      <h2>Quer que eu analise sua conta?</h2>
+      <p>Se você quer sair da teoria e ter um plano claro para escalar, agende sua hora comigo.</p>
+      <a class="btn btn--primary" href="hora-com-o-especialista.html">Agendar análise estratégica</a>
     </section>
 
     <section id="faq" class="faq">
@@ -558,8 +573,8 @@
     (function loadVersionedScripts() {
       const scripts = [
         "assets/js/storage.js?v=20260213-5",
-        "assets/js/pdf-export.js?v=20260213-5",
-        "assets/js/main.js?v=20260213-5"
+        "assets/js/pdf-export.js?v=20260213-4",
+        "assets/js/main.js?v=20260213-4"
       ];
 
       const loadNext = (index) => {


### PR DESCRIPTION
### Motivation
- Evoluir a calculadora para uma plataforma com UX profissional e estrutura preparada para conversão, sem tocar na lógica matemática nem remover GA4.
- Melhorar hierarquia de CTAs, organização visual dos cards, detalhamento de incidências, exportação PDF e adicionar seções de conteúdo (YouTube, serviço pago) para gerar leads.

### Description
- Reorganizei o topo com hierarquia de CTAs (WhatsApp primário sólido, página “A Hora com o Especialista” em outline, Instagram ghost) e padronizei estilos de botões; atualizei assets para `?v=20260213-4` (`styles.css`, `main.js`, `pdf-export.js`).
- Converti as abas em âncoras semânticas (`#precificacao`, `#comparar`, `#lucro`, `#escala`) e implementei `IntersectionObserver` para a classe `.is-active` e scroll suave; atualizei o mapeamento de seções no JS.
- Reestruturei os cards de marketplace: header com ícone + título em uppercase + pill de comissão, bloco de “PREÇO IDEAL” em destaque, grid com valores alinhados, e transformei “Total de incidências” em accordion animado (toggle com ícone rotativo e transição max-height); adicionei pequenas melhorias de CSS para suportar o layout.
- Melhorei o export PDF com cabeçalho solicitado (RELATÓRIO DE PRECIFICAÇÃO, Produto, Data, Domínio), fallback para `Produto sem nome`, título do relatório e layout por marketplace mais limpo.
- Adicionei faixa horizontal de vídeos do YouTube (`#youtube`) com thumbnails + título (carrossel leve) e função `renderYoutubeRail()` com um conjunto inicial de vídeos, e criei a nova página `/hora-com-o-especialista.html` com hero, benefícios, fluxo, antes/depois, investimento e CTA (pronta para integração de pagamento).
- Pequenas integrações: adição de `cta-specialist` tracking, manutenção de GA4, preservação completa da lógica de cálculo, e melhorias de acessibilidade/aria nas novas interações.

### Testing
- `node --check assets/js/main.js` — passou sem erros.
- `node --check assets/js/pdf-export.js` — passou sem erros.
- Servi o site localmente (`python -m http.server 4173`) e executei testes end-to-end de render com Playwright para a home e `/hora-com-o-especialista.html`, capturando screenshots que confirmaram a nova UX e interações (accordion, rail, CTAs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fa7808eb08332a09ae897fa53986f)