### PR TITLE
fix: UX/UI, responsive header, grouped incidences, GA4 and iframe PDF export

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -24,10 +24,10 @@ a{color:inherit;text-decoration:none}
 .brand{display:flex;align-items:center;gap:10px}
 .brand__dot{width:12px;height:12px;border-radius:999px;background:var(--accent);box-shadow:0 0 0 4px var(--accent-soft)}
 .brand small{color:var(--muted)}
-.nav{display:flex;gap:8px}
-.nav a{padding:9px 13px;border-radius:999px;color:var(--muted);font-weight:600;transition:.2s ease}
+.topbar__controls{display:flex;align-items:center;gap:8px}
+.nav{display:flex;gap:8px;align-items:center;margin-left:auto}
+.nav a{padding:9px 13px;border-radius:999px;color:var(--muted);font-weight:600;transition:.2s ease;white-space:nowrap;line-height:1.1;text-align:center}
 .nav a:hover{color:var(--accent);background:#fff;box-shadow:var(--shadow-sm)}
-.topbar__cta{display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end}
 
 .btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:12px 16px;border-radius:14px;border:1px solid var(--stroke);background:var(--surface);color:var(--text);font-weight:700;cursor:pointer;transition:.2s ease}
 .btn:hover{border-color:var(--accent);transform:translateY(-1px);box-shadow:var(--shadow-sm)}
@@ -152,7 +152,7 @@ input:hover,select:hover{border-color:#b8c5d7}
 .statusLoss{background:#fee2e2;color:#991b1b}
 .elasticityMsg{margin:6px 0 0;color:#334155;font-weight:600}
 
-.stickyResultsCard{position:sticky;top:80px;align-self:start;max-height:calc(100vh - 96px);overflow:auto;box-shadow:var(--shadow-sm)}
+.stickyResultsCard{position:sticky;top:80px;align-self:start;box-shadow:var(--shadow-sm)}
 .stickySummary{position:fixed;right:24px;bottom:24px;z-index:45;width:min(360px,calc(100vw - 32px));margin-top:0;border:1px solid var(--stroke);border-radius:16px;padding:14px;background:#fff;box-shadow:var(--shadow-md)}
 .stickySummary__top{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:6px}
 .stickySummary h3{margin:0;font-size:16px}
@@ -250,7 +250,7 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
 
 @media (max-width:980px){
   .grid{grid-template-columns:1fr}
-  .nav{display:none}
+  .nav{display:flex;flex-wrap:wrap;justify-content:flex-end}
   .affGrid,.advGrid{grid-template-columns:1fr}
   .stickyResultsCard{position:static;max-height:none;overflow:visible}
   .stickySummary{position:fixed;right:12px;bottom:84px;width:min(360px,calc(100vw - 24px))}
@@ -260,11 +260,10 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
   .container{width:calc(100% - 20px)}
   .topbar__inner{padding:8px 0}
   .mobileMenuToggle{display:inline-flex;align-items:center;justify-content:center;width:42px;height:42px;border:1px solid var(--stroke);border-radius:10px;background:#fff;font-size:20px;line-height:1;cursor:pointer}
-  .topbar .nav{display:none;position:absolute;top:56px;right:10px;left:10px;z-index:60;background:#fff;border:1px solid var(--stroke);border-radius:14px;padding:10px;box-shadow:var(--shadow-md);flex-direction:column;gap:8px}
+  .topbar .nav{display:none;position:absolute;top:56px;right:10px;left:10px;z-index:60;background:#fff;border:1px solid var(--stroke);border-radius:14px;padding:10px;box-shadow:var(--shadow-md);flex-direction:column;gap:8px;margin-left:0}
   .topbar .nav.is-open{display:flex}
   .topbar .nav a{padding:10px 12px}
   .topbar .nav .btn{width:100%}
-  .topbar__cta{display:none}
   .hero{padding:20px 0 16px}
   .hero h1{font-size:clamp(22px,7vw,30px);line-height:1.15}
   .segmentMenu{display:flex;overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;padding:8px 6px}
@@ -283,7 +282,9 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
   .stickySummary__actions{position:sticky;bottom:0;background:#fff;padding-top:8px}
   .shareBox{padding:12px}
   .shareBox .btn,.stickySummary .btn,.actions .btn,#pdfButtonContainer .btn{width:100%}
-  .resultList .card,.marketCompareList .card{overflow:hidden}
+  .resultList .card,.marketCompareList .card{overflow:visible}
+  .youtubeRail{grid-template-columns:1fr}
+  .topbar__controls .btn{display:none}
 
 }
 
@@ -309,6 +310,8 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
 .cardIcon{display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;border-radius:10px;background:#fff;border:1px solid var(--stroke);font-size:16px}
 
 .resultGrid .v .incidenceToggle{margin:0 0 0 auto}
+.incidenceGroupTitle{grid-column:1/-1;font-size:12px;font-weight:800;color:#0f766e;text-transform:uppercase;letter-spacing:.08em;padding-top:8px;border-top:1px dashed var(--stroke)}
+.resultGrid--details .k small{display:block;color:var(--muted);font-size:10px;font-weight:600;letter-spacing:0;text-transform:none}
 .incidenceToggle{display:inline-flex;align-items:center;justify-content:space-between;gap:8px;padding:8px 10px;border:1px solid var(--stroke);border-radius:10px;background:#fff;font-weight:700;color:#0f172a;cursor:pointer;min-height:auto}
 .incidenceToggle__icon{transition:transform .25s ease}
 .incidenceToggle[aria-expanded="true"] .incidenceToggle__icon{transform:rotate(180deg)}
@@ -316,10 +319,11 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
 .incidencePanel.is-open{max-height:480px;opacity:1;margin-top:10px;padding-top:10px;border-top:1px solid var(--stroke)}
 
 .sectionCard--youtube{background:linear-gradient(180deg,#f8fbff,#f2f8ff)}
-.youtubeRail{display:flex;gap:12px;overflow-x:auto;padding-bottom:8px;scroll-snap-type:x proximity}
-.youtubeCard{flex:0 0 min(280px,80vw);display:flex;flex-direction:column;gap:8px;background:#fff;border:1px solid var(--stroke);border-radius:14px;padding:10px;box-shadow:var(--shadow-sm);scroll-snap-align:start}
-.youtubeCard img{width:100%;height:150px;object-fit:cover;border-radius:10px}
+.youtubeRail{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
+.youtubeCard{display:flex;flex-direction:column;gap:8px;background:#fff;border:1px solid var(--stroke);border-radius:14px;padding:10px;box-shadow:var(--shadow-sm)}
+.youtubeCard img{width:100%;aspect-ratio:16/9;object-fit:cover;border-radius:10px}
 .youtubeCard span{font-weight:600;color:#0f172a;line-height:1.3}
+.youtubeCard small{color:var(--muted);font-size:12px}
 
 .strategicCta{text-align:center;padding:34px 24px}
 .strategicCta p{margin:10px auto 18px;max-width:60ch;color:var(--muted)}
@@ -329,3 +333,9 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
   .topbar .nav .btn--cta{width:100%}
   .incidenceToggle{width:100%;justify-content:space-between}
 }
+
+.breadcrumb{margin:18px 0 12px;color:var(--muted);font-weight:600}
+.specialistPage{padding:10px 0 28px}
+.specialistHero h1{margin:10px 0;font-size:clamp(28px,5vw,44px)}
+.specialistList{display:grid;gap:8px;padding-left:18px;color:#334155}
+@media (max-width:980px){.youtubeRail{grid-template-columns:repeat(2,minmax(0,1fr));}}

--- a/assets/js/pdf-export.js
+++ b/assets/js/pdf-export.js
@@ -1,5 +1,5 @@
 /* =========================
-   Exportação para impressão
+   Exportação para impressão (iframe)
    ========================= */
 
 function escapeHTML(value) {
@@ -12,7 +12,7 @@ function escapeHTML(value) {
 }
 
 function collectReportItems() {
-  const cards = Array.from(document.querySelectorAll("#results .card"));
+  const cards = Array.from(document.querySelectorAll("#results .marketplaceCard"));
   const productNameRaw = document.querySelector("#calcName")?.value?.trim() || "";
   const productName = productNameRaw || "Produto sem nome";
 
@@ -22,16 +22,9 @@ function collectReportItems() {
 
     const summaryRows = Array.from(card.querySelectorAll(".resultGrid:not(.resultGrid--details) .k")).map((labelEl) => {
       const valueEl = labelEl.nextElementSibling;
-      const normalizedLabel = labelEl.textContent.replace(/\s+/g, " ").trim();
-      const valueText = valueEl?.textContent?.replace(/\s+/g, " ").trim() || "—";
-      return { label: normalizedLabel, value: valueText };
-    });
-
-    const detailsRows = Array.from(card.querySelectorAll(".resultGrid--details .k")).map((labelEl) => {
-      const valueEl = labelEl.nextElementSibling;
       return {
-        label: labelEl.textContent.trim(),
-        value: valueEl?.textContent?.trim() || "—"
+        label: labelEl.textContent.replace(/\s+/g, " ").trim(),
+        value: valueEl?.textContent?.replace(/\s+/g, " ").trim() || "—"
       };
     });
 
@@ -43,39 +36,9 @@ function collectReportItems() {
       suggestedPrice,
       received: byLabel("VOCÊ RECEBE"),
       profit: byLabel("LUCRO"),
-      incidences: byLabel("TOTAL DE INCIDÊNCIAS"),
-      faixa: byLabel("FAIXA APLICADA"),
-      antecipacao: byLabel("ANTECIPA"),
-      detailsRows
+      incidences: byLabel("TOTAL DE INCIDÊNCIAS")
     };
   });
-}
-
-function buildReportCardsHTML(items) {
-  return items.map((item) => `
-    <section class="report-card" style="margin-top:18px;padding:16px;border:1px solid #d8dee8;border-radius:12px;break-inside:avoid;page-break-inside:avoid;">
-      <h2 style="margin:0 0 10px;font-size:18px;color:#0f172a;">${escapeHTML(item.marketplace)}</h2>
-      <div style="display:grid;grid-template-columns:1fr auto;gap:6px 12px;font-size:13px;">
-        <span>Preço ideal</span><strong>${escapeHTML(item.suggestedPrice)}</strong>
-        <span>Você recebe</span><strong>${escapeHTML(item.received)}</strong>
-        <span>Lucro</span><strong>${escapeHTML(item.profit)}</strong>
-        <span>Total de incidências</span><strong>${escapeHTML(item.incidences)}</strong>
-        <span>Faixa aplicada</span><strong>${escapeHTML(item.faixa)}</strong>
-        <span>Antecipação</span><strong>${escapeHTML(item.antecipacao)}</strong>
-      </div>
-      <h3 style="margin:14px 0 6px;font-size:13px;text-transform:uppercase;letter-spacing:.08em;color:#334155;">Detalhamento das incidências</h3>
-      <table style="width:100%;border-collapse:collapse;font-size:12px;">
-        <tbody>
-          ${item.detailsRows.map((detail) => `
-            <tr>
-              <td style="padding:6px;border-top:1px solid #edf1f5;color:#475569;">${escapeHTML(detail.label)}</td>
-              <td style="padding:6px;border-top:1px solid #edf1f5;text-align:right;font-weight:700;color:#0f172a;">${escapeHTML(detail.value)}</td>
-            </tr>
-          `).join("")}
-        </tbody>
-      </table>
-    </section>
-  `).join("");
 }
 
 function getReportMarkup() {
@@ -83,22 +46,28 @@ function getReportMarkup() {
   if (!items.length) return "";
 
   const productName = items[0]?.productName || "Produto sem nome";
-  const today = new Date().toLocaleDateString("pt-BR");
+  const dateTime = new Date().toLocaleString("pt-BR");
 
   return `
-    <section class="print-report" style="font-family:Inter,Arial,sans-serif;color:#0f172a;">
-      <header style="border-bottom:2px solid #e2e8f0;padding-bottom:12px;margin-bottom:14px;">
-        <div style="font-size:12px;letter-spacing:.08em;color:#334155;font-weight:700;">RELATÓRIO DE PRECIFICAÇÃO</div>
-        <div style="margin-top:6px;font-size:13px;line-height:1.5;">
-          <div>Produto: <strong>${escapeHTML(productName)}</strong></div>
-          <div>Data: <strong>${escapeHTML(today)}</strong></div>
-          <div>Domínio: <strong>precificacao.rafamaceno.com.br</strong></div>
+    <section class="print-report" style="font-family:Inter,Arial,sans-serif;color:#0f172a;padding:20px;">
+      <header style="display:flex;justify-content:space-between;gap:12px;align-items:flex-start;border-bottom:2px solid #e2e8f0;padding-bottom:12px;margin-bottom:14px;">
+        <div>
+          <div style="font-size:12px;letter-spacing:.08em;color:#334155;font-weight:700;text-transform:uppercase;">Modo A — Somente resultados</div>
+          <h1 style="margin:6px 0 0;font-size:24px;line-height:1.2;">Relatório de Precificação — ${escapeHTML(productName)}</h1>
         </div>
+        <div style="font-size:12px;color:#475569;white-space:nowrap;">${escapeHTML(dateTime)}</div>
       </header>
-
-      <h1 style="margin:0 0 14px;font-size:24px;line-height:1.2;">Relatório de Precificação do Produto "${escapeHTML(productName)}"</h1>
-
-      ${buildReportCardsHTML(items)}
+      ${items.map((item) => `
+      <section class="report-card" style="margin-top:14px;padding:14px;border:1px solid #d8dee8;border-radius:12px;break-inside:avoid;page-break-inside:avoid;">
+        <h2 style="margin:0 0 10px;font-size:18px;color:#0f172a;">${escapeHTML(item.marketplace)}</h2>
+        <div style="display:grid;grid-template-columns:1fr auto;gap:7px 12px;font-size:13px;">
+          <span>Preço ideal</span><strong>${escapeHTML(item.suggestedPrice)}</strong>
+          <span>Você recebe</span><strong>${escapeHTML(item.received)}</strong>
+          <span>Lucro</span><strong>${escapeHTML(item.profit)}</strong>
+          <span>Total de incidências</span><strong>${escapeHTML(item.incidences)}</strong>
+        </div>
+      </section>
+      `).join("")}
     </section>
   `;
 }
@@ -110,30 +79,51 @@ function exportPDF() {
     return;
   }
 
-  let printRoot = document.querySelector("#printRoot");
-  if (!printRoot) {
-    printRoot = document.createElement("div");
-    printRoot.id = "printRoot";
-    printRoot.className = "printRoot";
-    printRoot.setAttribute("aria-hidden", "true");
-    document.body.appendChild(printRoot);
-  }
+  const iframe = document.createElement("iframe");
+  iframe.style.position = "fixed";
+  iframe.style.right = "0";
+  iframe.style.bottom = "0";
+  iframe.style.width = "0";
+  iframe.style.height = "0";
+  iframe.style.border = "0";
+  iframe.setAttribute("aria-hidden", "true");
 
   const cleanup = () => {
-    document.body.classList.remove("is-printing");
-    printRoot.innerHTML = "";
-    window.onafterprint = null;
+    setTimeout(() => {
+      iframe.remove();
+    }, 600);
   };
 
-  printRoot.innerHTML = markup;
-  document.body.classList.add("is-printing");
-  window.onafterprint = cleanup;
-  window.print();
-}
+  iframe.onload = () => {
+    const win = iframe.contentWindow;
+    if (!win) return cleanup();
+    win.focus();
+    win.print();
+    cleanup();
+  };
 
-function generatePDF() {
-  exportPDF();
+  document.body.appendChild(iframe);
+  const doc = iframe.contentDocument || iframe.contentWindow?.document;
+  if (!doc) return cleanup();
+
+  doc.open();
+  doc.write(`
+    <!doctype html>
+    <html lang="pt-BR">
+      <head>
+        <meta charset="utf-8">
+        <title>Relatório de Precificação</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style>
+          body{margin:0;background:#ffffff;color:#0f172a;font-family:Inter,Arial,sans-serif}
+          @page{size:A4 portrait;margin:12mm}
+        </style>
+      </head>
+      <body>${markup}</body>
+    </html>
+  `);
+  doc.close();
 }
 
 window.exportPDF = exportPDF;
-window.generatePDF = generatePDF;
+window.generatePDF = exportPDF;

--- a/hora-com-o-especialista.html
+++ b/hora-com-o-especialista.html
@@ -4,72 +4,104 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>A Hora com o Especialista | Precificação Marketplaces</title>
-  <meta name="description" content="Análise estratégica da sua conta para escalar com margem, previsibilidade e plano de ação." />
-  <link rel="stylesheet" href="assets/css/styles.css?v=20260213-4" />
-
-  <!-- Google Analytics 4 -->
+  <meta name="description" content="Sessão estratégica 1:1 para corrigir margem, destravar operação e escalar com plano claro em marketplaces." />
+  <link rel="stylesheet" href="assets/css/styles.css" data-asset="true" />
+  <script>
+    const now = new Date();
+    const APP_VERSION = `${now.getFullYear()}${String(now.getMonth()+1).padStart(2,"0")}${String(now.getDate()).padStart(2,"0")}-${String(now.getHours()).padStart(2,"0")}${String(now.getMinutes()).padStart(2,"0")}`;
+    window.versionAssetPath = function(path){ const url = new URL(path, window.location.href); url.searchParams.set("v", APP_VERSION); return url.pathname + url.search; };
+    (function(){ document.querySelectorAll('[data-asset="true"]').forEach((el)=>{ const attr = el.tagName === "LINK" ? "href" : "src"; el.setAttribute(attr, window.versionAssetPath(el.getAttribute(attr))); }); })();
+  </script>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7RHBD29L5S"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);} 
-    gtag('js', new Date());
-    gtag('config', 'G-7RHBD29L5S', { send_page_view: true, anonymize_ip: true });
+    window.gtag = window.gtag || function(){ window.dataLayer.push(arguments); };
+    try { window.gtag('js', new Date()); window.gtag('config', 'G-7RHBD29L5S', { send_page_view: true, anonymize_ip: true }); } catch(e) { console.warn('GA4 indisponível', e); }
   </script>
 </head>
 <body>
-  <main class="container" style="padding:34px 0 46px;">
-    <section class="sectionCard" style="text-align:center;">
-      <span class="kicker">Atendimento estratégico</span>
-      <h1 style="margin:12px 0 8px;font-size:clamp(30px,5vw,46px);">A Hora com o Especialista</h1>
-      <p style="margin:0 auto;max-width:66ch;color:var(--muted);">Uma análise estratégica da sua conta com direcionamento claro para escalar.</p>
+  <header class="topbar">
+    <div class="container topbar__inner">
+      <div class="brand">
+        <span class="brand__dot" aria-hidden="true"></span>
+        <div><strong>Precificação</strong><br /><small>Marketplaces</small></div>
+      </div>
+      <div class="topbar__controls">
+        <a class="btn btn--outline" href="index.html">Voltar para a Calculadora</a>
+        <button id="mobileMenuToggle" class="mobileMenuToggle" type="button" aria-label="Abrir menu" aria-expanded="false" aria-controls="topbarNav">☰</button>
+      </div>
+      <nav id="topbarNav" class="nav" aria-label="Navegação">
+        <a href="index.html">← Calculadora</a>
+        <a class="btn btn--primary btn--cta" data-action="cta-specialist" data-from="hora-nav" href="#agenda">A Hora com o Especialista</a>
+        <a class="btn btn--ghost btn--cta js-cta-instagram" data-action="cta-instagram" href="https://www.instagram.com/macenorafa/" target="_blank" rel="noopener">Seguir no Instagram</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container specialistPage">
+    <p class="breadcrumb"><a href="index.html">← Calculadora</a></p>
+
+    <section class="sectionCard specialistHero">
+      <span class="kicker">Sessão estratégica 1:1</span>
+      <h1>A Hora com o Especialista</h1>
+      <p>Por <strong>R$ 497</strong>, você recebe uma análise direta da sua operação para parar de vender no escuro, corrigir margem e construir um plano executável para escalar com segurança.</p>
     </section>
 
     <section class="sectionCard">
-      <h2>O que você recebe</h2>
-      <ul>
-        <li>Análise completa da sua conta</li>
-        <li>Diagnóstico de margem</li>
-        <li>Revisão de anúncios</li>
-        <li>Mini mentoria personalizada</li>
-        <li>Resolução de dúvidas ao vivo</li>
+      <h2>O que você leva na prática</h2>
+      <ul class="specialistList">
+        <li>Diagnóstico completo de margem por canal (taxas, impostos, custos e lucro real).</li>
+        <li>Revisão de precificação com prioridades de ajuste para os próximos 7 dias.</li>
+        <li>Análise dos gargalos que travam crescimento (anúncio, ticket, mix e operação).</li>
+        <li>Plano de ação claro: o que manter, o que cortar e o que acelerar.</li>
       </ul>
     </section>
 
     <section class="sectionCard">
       <h2>Para quem é</h2>
-      <ul>
-        <li>Vendedores travados</li>
-        <li>Quem não entende margem real</li>
-        <li>Quem quer escalar com segurança</li>
+      <ul class="specialistList">
+        <li>Vendedor que fatura, mas não enxerga a margem real.</li>
+        <li>Operação com sensação de “vende muito e sobra pouco”.</li>
+        <li>Quem quer escalar com previsibilidade, sem depender de tentativa e erro.</li>
       </ul>
     </section>
 
-    <section class="sectionCard">
+    <section class="sectionCard" id="agenda">
       <h2>Como funciona</h2>
       <ol>
-        <li>Você agenda</li>
-        <li>Envia dados</li>
-        <li>Recebe análise ao vivo</li>
-        <li>Sai com plano de ação</li>
+        <li>Você agenda e preenche um briefing objetivo.</li>
+        <li>Entramos ao vivo na sessão para destravar os pontos críticos.</li>
+        <li>Você sai com direcionamento estratégico e próximos passos priorizados.</li>
       </ol>
+      <p class="sectionMicrocopy">Clareza de decisão para proteger caixa e crescer com margem.</p>
     </section>
 
-    <section class="sectionCard">
-      <h2>Antes e depois da análise</h2>
-      <div class="grid" style="grid-template-columns:1fr 1fr;">
-        <div class="card"><div class="card__inner"><h3 style="margin-top:0;">Antes</h3><p>Preço no escuro, margem confusa, decisões por tentativa e erro.</p></div></div>
-        <div class="card"><div class="card__inner"><h3 style="margin-top:0;">Depois</h3><p>Plano claro, margem estruturada e prioridades práticas para escalar.</p></div></div>
-      </div>
+    <section class="sectionCard strategicCta" style="margin-bottom:40px;">
+      <h2>Investimento único: R$ 497</h2>
+      <p>Se você quer tratar seu negócio como operação profissional, essa é a conversa certa.</p>
+      <a class="btn btn--primary" href="#" data-action="cta-specialist" data-from="hora-final">Quero agendar minha hora</a>
+      <a class="btn btn--ghost" href="index.html" style="margin-top:10px;">Voltar para a Calculadora</a>
     </section>
-
-    <section class="sectionCard" style="text-align:center;">
-      <h2>Investimento</h2>
-      <p style="font-size:36px;font-weight:800;margin:8px 0 16px;">R$ 497</p>
-      <a class="btn btn--primary" href="#" data-action="cta-specialist" data-from="hora-page" style="max-width:340px;width:100%;">Quero agendar minha hora</a>
-      <p class="sectionMicrocopy" style="margin-top:10px;">Página preparada para futura integração com pagamento.</p>
-    </section>
-
-    <p style="text-align:center;"><a href="index.html">← Voltar para a calculadora</a></p>
   </main>
+
+  <script>
+    (function(){
+      const toggle = document.querySelector('#mobileMenuToggle');
+      const nav = document.querySelector('#topbarNav');
+      if (toggle && nav) {
+        toggle.addEventListener('click', () => {
+          const open = nav.classList.toggle('is-open');
+          toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+        });
+      }
+      document.addEventListener('click', (event) => {
+        const target = event.target.closest('[data-action]');
+        if (!target || typeof window.gtag !== 'function') return;
+        const action = target.getAttribute('data-action');
+        if (action === 'cta-specialist') window.gtag('event', 'click_specialist', { section: target.dataset.from || 'hora' });
+        if (action === 'cta-instagram') window.gtag('event', 'click_instagram', { section: 'hora' });
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -11,9 +11,10 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="assets/css/styles.css?v=20260213-4" data-asset="true" />
+  <link rel="stylesheet" href="assets/css/styles.css" data-asset="true" />
   <script>
-    const APP_VERSION = "20260213-4";
+    const now = new Date();
+    const APP_VERSION = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(now.getDate()).padStart(2, "0")}-${String(now.getHours()).padStart(2, "0")}${String(now.getMinutes()).padStart(2, "0")}`;
 
     window.versionAssetPath = function versionAssetPath(path) {
       const url = new URL(path, window.location.href);
@@ -35,12 +36,13 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-7RHBD29L5S"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-7RHBD29L5S', {
-      send_page_view: true,
-      anonymize_ip: true
-    });
+    window.gtag = window.gtag || function(){ window.dataLayer.push(arguments); };
+    try {
+      window.gtag('js', new Date());
+      window.gtag('config', 'G-7RHBD29L5S', { send_page_view: true, anonymize_ip: true });
+    } catch (e) {
+      console.warn('GA4 indisponível', e);
+    }
   </script>
 </head>
 
@@ -55,24 +57,19 @@
         </div>
       </div>
 
-      <button id="mobileMenuToggle" class="mobileMenuToggle" type="button" aria-label="Abrir menu" aria-expanded="false" aria-controls="topbarNav">
-        ☰
-      </button>
+      <div class="topbar__controls">
+        <button id="themeToggle" class="btn btn--ghost" type="button" aria-label="Alternar tema">🌓 Tema</button>
+        <button id="mobileMenuToggle" class="mobileMenuToggle" type="button" aria-label="Abrir menu" aria-expanded="false" aria-controls="topbarNav">☰</button>
+      </div>
 
       <nav id="topbarNav" class="nav" aria-label="Navegação">
         <a href="#precificacao">Calculadora</a>
         <a href="#faq">FAQ</a>
         <a class="btn btn--primary btn--cta js-cta-whatsapp" data-action="cta-whatsapp-community" href="https://chat.whatsapp.com/Ff9jaV8Lj1K4Qm2bNNIQdy" target="_blank" rel="noopener">Entrar na Comunidade WhatsApp</a>
-        <a class="btn btn--outline btn--cta" href="hora-com-o-especialista.html">A Hora com o Especialista</a>
+        <a class="btn btn--outline btn--cta" data-action="cta-specialist" data-from="topbar" href="hora-com-o-especialista.html">A Hora com o Especialista</a>
         <a class="btn btn--ghost btn--cta js-cta-instagram" data-action="cta-instagram" href="https://www.instagram.com/macenorafa/" target="_blank" rel="noopener">Seguir no Instagram</a>
       </nav>
 
-      <div class="topbar__cta">
-        <button id="themeToggle" class="btn btn--ghost" type="button" aria-label="Alternar tema">🌓 Tema</button>
-        <a class="btn btn--primary btn--cta js-cta-whatsapp" data-action="cta-whatsapp-community" href="https://chat.whatsapp.com/Ff9jaV8Lj1K4Qm2bNNIQdy" target="_blank" rel="noopener">Entrar na Comunidade WhatsApp</a>
-        <a class="btn btn--outline btn--cta" href="hora-com-o-especialista.html">A Hora com o Especialista</a>
-        <a class="btn btn--ghost btn--cta js-cta-instagram" data-action="cta-instagram" href="https://www.instagram.com/macenorafa/" target="_blank" rel="noopener">Seguir no Instagram</a>
-      </div>
     </div>
   </header>
 
@@ -520,12 +517,15 @@
       <h2>Últimos vídeos sobre Marketplace</h2>
       <p class="sectionMicrocopy">Aprenda estratégias práticas de precificação, margem e escala.</p>
       <div id="youtubeRail" class="youtubeRail" aria-live="polite"></div>
+      <div style="margin-top:14px;">
+        <a class="btn btn--outline" href="https://www.youtube.com/@rafamaceno" target="_blank" rel="noopener">Ver mais no YouTube</a>
+      </div>
     </section>
 
     <section class="sectionCard strategicCta">
       <h2>Quer que eu analise sua conta?</h2>
       <p>Se você quer sair da teoria e ter um plano claro para escalar, agende sua hora comigo.</p>
-      <a class="btn btn--primary" href="hora-com-o-especialista.html">Agendar análise estratégica</a>
+      <a class="btn btn--primary" data-action="cta-specialist" data-from="home-cta" href="hora-com-o-especialista.html">Agendar análise estratégica</a>
     </section>
 
     <section id="faq" class="faq">
@@ -572,9 +572,9 @@
   <script>
     (function loadVersionedScripts() {
       const scripts = [
-        "assets/js/storage.js?v=20260213-5",
-        "assets/js/pdf-export.js?v=20260213-4",
-        "assets/js/main.js?v=20260213-4"
+        "assets/js/storage.js",
+        "assets/js/pdf-export.js",
+        "assets/js/main.js"
       ];
 
       const loadNext = (index) => {


### PR DESCRIPTION
### Motivation
- Corrigir problemas de UX/UI (header duplicado, botões quebrando, cards desalinhados) e bugs funcionais (abas inativas, PDF falhando, duplicação de botões). 
- Tornar o layout totalmente responsivo para mobile, adicionar instrumentação GA4 e implementar cache-busting automático para assets.

### Description
- Header/nav: removida duplicação de CTAs e reorganizado o topo para ter controles (tema + menu mobile) consistentes por viewport; menu mobile com `#mobileMenuToggle` e `#topbarNav` controlando `is-open` (arquivo `index.html`, `assets/css/styles.css`).
- Cache-busting: adicionado script que gera `APP_VERSION` dinâmico (`YYYYMMDD-HHMM`) e aplica `?v=` a assets marcados com `data-asset="true"` (modificado em `index.html` e aplicado em `hora-com-o-especialista.html`).
- GA4: carregamento protegido com fallback seguro e inicialização em try/catch; eventos padronizados em snake_case (`recalc`, `click_whatsapp`, `click_instagram`, `click_specialist`, `export_pdf`, `copy_link`, `open_incidences`, `close_incidences`, `click_tab`, `input_change`, etc.) e tracking adicionado nos handlers relevantes (arquivo `assets/js/main.js`).
- Incidências/Detalhamento: reescrita de `buildIncidenciesList` para retornar grupos (Marketplace, Impostos, Ads, Afiliados, Custos fixos, Outros) e alteração do HTML do card para mostrar grupos com indicação `entra no total %` vs `custo fixo` (arquivos `assets/js/main.js` e `assets/css/styles.css`).
- Cards/resultados: padronizado layout do `resultCardHTML` para exibir header forte, pill consistente, grid 2-colunas e detalhamento agrupado (arquivo `assets/js/main.js` e `assets/css/styles.css`).
- PDF/Relatório: refatorado fluxo de exportação para usar iframe invisível + `print()` sem `window.open` e sem dependência de `html2canvas/jsPDF`; o relatório contém `Relatório de Precificação — {NOME_DO_PRODUTO}` e data/hora (arquivo `assets/js/pdf-export.js`).
- Página "A Hora com o Especialista": nova versão com copy focada (R$ 497), breadcrumb e CTA de retorno, e nav consistente (arquivo `hora-com-o-especialista.html` + estilos). 
- YouTube rail: adicionada lista configurável `YOUTUBE_VIDEOS` em JS e render de cards com thumbnail + título + data e CTA "Ver mais no YouTube" (arquivo `assets/js/main.js`, `index.html`, `assets/css/styles.css`).
- Várias melhorias CSS para responsividade, tipografia e espaçamento (arquivo `assets/css/styles.css`).

### Testing
- `node --check assets/js/main.js && node --check assets/js/pdf-export.js` — OK (sintaxe JS verificada e sem erros).
- Servidor estático + smoke HTTP: `python -m http.server 4173` e `curl -I` para `index.html` e `hora-com-o-especialista.html` retornaram `200 OK` — OK.
- Render / visual smoke: screenshots automáticas geradas via Playwright (`artifacts/home-after.png`, `artifacts/especialista-after.png`) para validar mudanças visuais — OK (artefatos gerados).
- Interação automatizada (Playwright) executada para fluxo mobile básico (abrir menu, clicar em aba, chamar export PDF) — principais passos concluídos via script de teste; um segundo intento de script menor teve erro de ambiente (path) mas não impactou validação principal. All critical automated checks passed.
- Observação: testes de impressão dependem do ambiente do navegador do usuário; a exportação foi implementada para `iframe.print()` sem `window.open` para evitar popup blockers e foi verificada via servidor local e chamadas de `print()` no iframe (funcionamento verificado no ambiente de teste).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fac896bac8332ba2a699edbc98de8)