### PR TITLE
feat: Seção YouTube premium com rail mobile estilo Netflix e cache busting

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -283,7 +283,6 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
   .shareBox{padding:12px}
   .shareBox .btn,.stickySummary .btn,.actions .btn,#pdfButtonContainer .btn{width:100%}
   .resultList .card,.marketCompareList .card{overflow:visible}
-  .youtubeRail{grid-template-columns:1fr}
   .topbar__controls .btn{display:none}
 
 }
@@ -319,11 +318,22 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
 .incidencePanel.is-open{max-height:480px;opacity:1;margin-top:10px;padding-top:10px;border-top:1px solid var(--stroke)}
 
 .sectionCard--youtube{background:linear-gradient(180deg,#f8fbff,#f2f8ff)}
-.youtubeRail{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
-.youtubeCard{display:flex;flex-direction:column;gap:8px;background:#fff;border:1px solid var(--stroke);border-radius:14px;padding:10px;box-shadow:var(--shadow-sm)}
-.youtubeCard img{width:100%;aspect-ratio:16/9;object-fit:cover;border-radius:10px}
-.youtubeCard span{font-weight:600;color:#0f172a;line-height:1.3}
-.youtubeCard small{color:var(--muted);font-size:12px}
+.yt-section{overflow:hidden}
+.yt-head{display:flex;align-items:flex-end;justify-content:space-between;gap:14px;margin-bottom:14px}
+.yt-more{display:inline-flex;align-items:center;justify-content:center;padding:10px 14px;border-radius:12px;border:1px solid #0f172a;color:#0f172a;font-weight:700;text-decoration:none;transition:all .2s ease;white-space:nowrap}
+.yt-more:hover{background:#0f172a;color:#fff}
+.yt-more:focus-visible,.yt-card:focus-visible{outline:3px solid color-mix(in srgb,var(--accent) 60%,#fff);outline-offset:3px}
+.yt-rail{display:flex;gap:16px;overflow-x:auto;overflow-y:hidden;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;padding:2px 14px 12px 2px;margin:0 -2px;scrollbar-width:none;overscroll-behavior-x:contain;mask-image:linear-gradient(to right,transparent 0,#000 24px,#000 calc(100% - 24px),transparent 100%)}
+.yt-rail::-webkit-scrollbar{display:none}
+.yt-card{flex:0 0 78%;max-width:320px;scroll-snap-align:start;display:flex;flex-direction:column;gap:10px;background:#fff;border:1px solid var(--stroke);border-radius:16px;padding:10px;text-decoration:none;box-shadow:0 10px 24px -18px rgba(15,23,42,.45);transition:transform .2s ease,box-shadow .2s ease,border-color .2s ease}
+.yt-card:hover{transform:translateY(-3px);box-shadow:0 16px 30px -20px rgba(15,23,42,.45);border-color:#cbd5e1}
+.yt-thumbWrap{position:relative;border-radius:14px;overflow:hidden}
+.yt-thumb{width:100%;aspect-ratio:16/9;object-fit:cover;display:block}
+.yt-badge{position:absolute;top:10px;left:10px;padding:4px 9px;border-radius:999px;background:rgba(255,255,255,.85);border:1px solid rgba(148,163,184,.45);backdrop-filter:blur(4px);font-size:11px;font-weight:700;color:#0f172a}
+.yt-meta{display:flex;flex-direction:column;gap:10px;padding:2px}
+.yt-title{font-weight:700;line-height:1.35;color:#0f172a;min-height:2.7em;text-wrap:balance}
+.yt-cta{display:inline-flex;align-items:center;justify-content:center;min-height:38px;padding:8px 12px;border-radius:10px;background:var(--accent);color:#fff;font-weight:700;transition:background .2s ease}
+.yt-card:hover .yt-cta{background:#0b8f72}
 
 .strategicCta{text-align:center;padding:34px 24px}
 .strategicCta p{margin:10px auto 18px;max-width:60ch;color:var(--muted)}
@@ -338,4 +348,13 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
 .specialistPage{padding:10px 0 28px}
 .specialistHero h1{margin:10px 0;font-size:clamp(28px,5vw,44px)}
 .specialistList{display:grid;gap:8px;padding-left:18px;color:#334155}
-@media (max-width:980px){.youtubeRail{grid-template-columns:repeat(2,minmax(0,1fr));}}
+
+@media (min-width:768px){
+  .yt-rail{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));overflow:visible;padding:2px;mask-image:none}
+  .yt-card{flex:1 1 auto;max-width:none;height:100%}
+}
+
+@media (max-width:767px){
+  .yt-head{flex-direction:column;align-items:flex-start}
+  .yt-more{width:100%}
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -28,13 +28,6 @@ const INPUT_EVENT_FIELDS = {
 const THEME_KEY = "pricing_theme";
 const SAVED_SIMULATIONS_KEY = "saved_simulations_v2";
 
-const YOUTUBE_VIDEOS = [
-  { id: "7z2lR8mWQmM", title: "Como precificar sem destruir sua margem", publishedAt: "2026-01-12" },
-  { id: "k3yGf2mZp9A", title: "Erro de comissão que trava seu lucro", publishedAt: "2026-01-05" },
-  { id: "Q8kLm2nVx1c", title: "Escala com margem real em marketplace", publishedAt: "2025-12-26" },
-  { id: "m5Pq9rT2uYb", title: "Preço ideal para vender mais e lucrar", publishedAt: "2025-12-10" },
-  { id: "b4Nw6dX1sZa", title: "Diagnóstico rápido de operação no marketplace", publishedAt: "2025-11-30" }
-];
 
 function track(eventName, params = {}) {
   try {
@@ -1482,20 +1475,6 @@ function bindSegmentMenuActiveState() {
   });
 }
 
-function renderYoutubeRail() {
-  const wrap = document.querySelector("#youtubeRail");
-  if (!wrap) return;
-  wrap.innerHTML = YOUTUBE_VIDEOS.map((video) => {
-    const dateText = video.publishedAt ? new Date(video.publishedAt + "T12:00:00").toLocaleDateString("pt-BR") : "";
-    return `
-    <a class="youtubeCard" href="https://www.youtube.com/watch?v=${video.id}" target="_blank" rel="noopener">
-      <img src="https://img.youtube.com/vi/${video.id}/hqdefault.jpg" alt="Thumbnail do vídeo ${video.title}">
-      <span>${video.title || "Assista no YouTube"}</span>
-      <small>${dateText}</small>
-    </a>`;
-  }).join("");
-}
-
 function initApp() {
   const params = new URLSearchParams(window.location.search);
   const sharedState = params.get("state");
@@ -1517,7 +1496,6 @@ function initApp() {
   bindTooltipSystem();
   bindStickySummaryVisibility();
   bindSegmentMenuActiveState();
-  renderYoutubeRail();
   renderSavedSimulations();
   track("session_ready", { device: getDeviceType() });
   recalc({ source: "auto" });

--- a/index.html
+++ b/index.html
@@ -13,8 +13,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/styles.css" data-asset="true" />
   <script>
-    const now = new Date();
-    const APP_VERSION = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(now.getDate()).padStart(2, "0")}-${String(now.getHours()).padStart(2, "0")}${String(now.getMinutes()).padStart(2, "0")}`;
+    const APP_VERSION = "20260213-2";
 
     window.versionAssetPath = function versionAssetPath(path) {
       const url = new URL(path, window.location.href);
@@ -513,12 +512,59 @@
     </section>
 
 
-    <section id="youtube" class="sectionCard sectionCard--youtube">
-      <h2>Últimos vídeos sobre Marketplace</h2>
-      <p class="sectionMicrocopy">Aprenda estratégias práticas de precificação, margem e escala.</p>
-      <div id="youtubeRail" class="youtubeRail" aria-live="polite"></div>
-      <div style="margin-top:14px;">
-        <a class="btn btn--outline" href="https://www.youtube.com/@rafamaceno" target="_blank" rel="noopener">Ver mais no YouTube</a>
+    <section id="youtube" class="sectionCard sectionCard--youtube yt-section">
+      <div class="yt-head">
+        <div>
+          <h2>Últimos vídeos sobre Marketplace</h2>
+          <p class="sectionMicrocopy">Aprenda estratégias práticas de precificação, margem e escala.</p>
+        </div>
+        <a class="yt-more" href="https://www.youtube.com/@rafamaceno" target="_blank" rel="noopener">Ver mais no YouTube</a>
+      </div>
+
+      <div class="yt-rail" aria-label="Vídeos do YouTube">
+        <a class="yt-card" href="https://www.youtube.com/watch?v=WG9UqrU4Nos" target="_blank" rel="noopener">
+          <div class="yt-thumbWrap">
+            <img class="yt-thumb" src="https://i.ytimg.com/vi/WG9UqrU4Nos/hqdefault.jpg" alt="Como precificar sem destruir sua margem">
+            <span class="yt-badge">YouTube</span>
+          </div>
+          <div class="yt-meta">
+            <div class="yt-title">Como precificar sem destruir sua margem</div>
+            <div class="yt-cta">Assistir agora</div>
+          </div>
+        </a>
+
+        <a class="yt-card" href="https://www.youtube.com/watch?v=MD0HOadjZso" target="_blank" rel="noopener">
+          <div class="yt-thumbWrap">
+            <img class="yt-thumb" src="https://i.ytimg.com/vi/MD0HOadjZso/hqdefault.jpg" alt="Erro de comissão que trava seu lucro">
+            <span class="yt-badge">YouTube</span>
+          </div>
+          <div class="yt-meta">
+            <div class="yt-title">Erro de comissão que trava seu lucro</div>
+            <div class="yt-cta">Assistir agora</div>
+          </div>
+        </a>
+
+        <a class="yt-card" href="https://www.youtube.com/watch?v=gsk92dLOhK8" target="_blank" rel="noopener">
+          <div class="yt-thumbWrap">
+            <img class="yt-thumb" src="https://i.ytimg.com/vi/gsk92dLOhK8/hqdefault.jpg" alt="Escala com margem real em marketplace">
+            <span class="yt-badge">YouTube</span>
+          </div>
+          <div class="yt-meta">
+            <div class="yt-title">Escala com margem real em marketplace</div>
+            <div class="yt-cta">Assistir agora</div>
+          </div>
+        </a>
+
+        <a class="yt-card" href="https://www.youtube.com/watch?v=2tS-sINkmdc" target="_blank" rel="noopener">
+          <div class="yt-thumbWrap">
+            <img class="yt-thumb" src="https://i.ytimg.com/vi/2tS-sINkmdc/hqdefault.jpg" alt="Preço ideal para vender mais e lucrar">
+            <span class="yt-badge">YouTube</span>
+          </div>
+          <div class="yt-meta">
+            <div class="yt-title">Preço ideal para vender mais e lucrar</div>
+            <div class="yt-cta">Assistir agora</div>
+          </div>
+        </a>
       </div>
     </section>
 


### PR DESCRIPTION
### Motivation
- Melhorar a seção de YouTube no final da página para ficar mais premium, com 4 vídeos fixos sem usar API e thumbnails reais do YouTube. 
- No mobile oferecer experiência tipo "Netflix" (carrossel horizontal com snap) e no desktop manter uma grade responsiva e alinhada ao visual do site.

### Description
- Substitui a seção antiga por uma seção manual em `index.html` com 4 cards fixos usando os IDs e títulos fornecidos e thumbnails via `https://i.ytimg.com/vi/<VIDEO_ID>/hqdefault.jpg`, todos os links abrindo em nova aba com `target="_blank" rel="noopener"`.
- Adicionei estilos premium em `assets/css/styles.css` (`.yt-section`, `.yt-head`, `.yt-rail`, `.yt-card`, `.yt-thumbWrap`, `.yt-thumb`, `.yt-badge`, `.yt-meta`, `.yt-cta`) com borda, sombra suave, hover/focus visível, thumb 16:9 com `object-fit: cover`, edge fade via `mask-image` e comportamento responsivo (rail com `scroll-snap-type` em mobile e grid em >=768px).
- Removi a renderização dinâmica anterior da seção de vídeos em `assets/js/main.js` (remoção de `YOUTUBE_VIDEOS` e `renderYoutubeRail`), passando a manter o conteúdo 100% manual no HTML.
- Padronizei cache busting de assets em `index.html` definindo `APP_VERSION = "20260213-2"` e aplicando `?v=` a CSS/JS via `window.versionAssetPath(...)` para garantir uma versão única consistente nos assets carregados.

### Testing
- Levantei um servidor local com `python3 -m http.server 4173` e capturei screenshots desktop/mobile via Playwright para validar visual e comportamento; a geração dos arquivos `artifacts/youtube-desktop.png` e `artifacts/youtube-mobile.png` foi bem-sucedida.
- Verifiquei presença dos IDs/títulos/paths com `rg` e confirmei as referências a `WG9UqrU4Nos`, `MD0HOadjZso`, `gsk92dLOhK8`, `2tS-sINkmdc`, `yt-rail`, `yt-card` e `APP_VERSION` nos arquivos modificados; buscas retornaram resultados esperados.
- Confirmei que os requests de assets incluem a querystring `?v=20260213-2` durante navegação local (verificado nos logs do servidor HTTP); testes automatizados executados completaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fb3201f108332aca3c8e5cf1f539b)