### PR TITLE
Refatora formulário de Precificação — essencial primeiro, comissões/ajustes opcionais

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -72,6 +72,30 @@ input:hover,select:hover{border-color:#b8c5d7}
 .check input{width:18px;height:18px}
 .check--inline{margin-bottom:10px}
 .hidden{display:none!important}
+.is-hidden{display:none!important}
+
+.formBlock{display:flex;flex-direction:column;gap:4px}
+.formBlock__head h3{margin:0;font-size:17px;letter-spacing:-.01em}
+.formBlock__head p{margin:4px 0 0;color:var(--muted);font-size:13px}
+.formDivider{height:1px;background:var(--stroke);margin:16px 0}
+.formBlock--actions{gap:10px}
+
+.segmented{display:grid;grid-template-columns:1fr 1fr;gap:8px;padding:5px;border:1px solid var(--stroke);border-radius:12px;background:#f8fafc}
+.segmented__option{position:relative;cursor:pointer}
+.segmented__option input{position:absolute;opacity:0;inset:0;margin:0}
+.segmented__option span{display:flex;align-items:center;justify-content:center;min-height:40px;padding:8px 10px;border-radius:10px;font-weight:700;color:#334155;transition:.2s ease}
+.segmented__option input:checked + span{background:#fff;color:var(--accent);border:1px solid #bcefeb;box-shadow:var(--shadow-sm)}
+
+.formInfoDetails{margin:8px 0 0;padding:0;border:none;background:transparent}
+.formInfoDetails summary{font-size:13px;color:#334155}
+.formInfoDetails p{margin:8px 0 0;padding:10px;border:1px solid var(--stroke);border-radius:12px;background:#f8fafc;color:var(--muted);font-size:12px}
+
+.formAccordion{margin-top:14px;padding:0;border:1px solid var(--stroke);border-radius:14px;background:#fff;overflow:hidden}
+.formAccordion summary{list-style:none;display:flex;align-items:center;justify-content:space-between;padding:14px;font-size:14px;color:#0f172a}
+.formAccordion summary::-webkit-details-marker{display:none}
+.formAccordion summary::after{content:"▾";font-size:14px;color:var(--muted);transition:transform .2s ease}
+.formAccordion[open] summary::after{transform:rotate(180deg)}
+.formAccordion > :not(summary){padding:0 14px 14px}
 
 .cardMini{margin-top:14px;border-radius:14px;border:1px solid var(--stroke);background:#fff;padding:14px}
 .cardMini__header{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px}
@@ -283,6 +307,9 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
   .stickySummary__actions{position:sticky;bottom:0;background:#fff;padding-top:8px}
   .shareBox{padding:12px}
   .shareBox .btn,.stickySummary .btn,.actions .btn,#pdfButtonContainer .btn{width:100%}
+  .formAccordion summary{padding:12px 12px}
+  .formAccordion > :not(summary){padding:0 12px 12px}
+  .segmented{grid-template-columns:1fr}
   .resultList .card,.marketCompareList .card{overflow:visible}
   .topbar__controls .btn{display:none}
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -922,8 +922,9 @@ function recalc(options = {}) {
   const profitType = document.querySelector("#profitType")?.value || "brl";
   const profitValue = Math.max(0, toNumber(document.querySelector("#profitValue")?.value));
 
-  const mlClassicPct = toNumber(document.querySelector("#mlClassicPct")?.value) / 100;
-  const mlPremiumPct = toNumber(document.querySelector("#mlPremiumPct")?.value) / 100;
+  const mlCommissionEnabled = document.querySelector("#mlCommissionToggle")?.checked;
+  const mlClassicPct = (mlCommissionEnabled ? toNumber(document.querySelector("#mlClassicPct")?.value) : 14) / 100;
+  const mlPremiumPct = (mlCommissionEnabled ? toNumber(document.querySelector("#mlPremiumPct")?.value) : 19) / 100;
 
   const adv = getAdvancedVars();
 
@@ -955,7 +956,10 @@ function recalc(options = {}) {
   });
 
   /* ===== SHEIN ===== */
-  const sheinCategory = document.querySelector("#sheinCategory")?.value || "other";
+  const sheinCommissionEnabled = document.querySelector("#sheinCommissionToggle")?.checked;
+  const sheinCategory = sheinCommissionEnabled
+    ? (document.querySelector("#sheinCategory")?.value || "other")
+    : "other";
   const sheinPct = sheinCategory === "female" ? SHEIN.pctFemale : SHEIN.pctOther;
   const sheinFixed = sheinFixedByWeight(weightKg);
 
@@ -1117,7 +1121,7 @@ function recalc(options = {}) {
   const amazonOriginWrap = document.querySelector("#amazonOriginWrap");
   if (amazonOriginWrap) {
     const shouldShowOrigin = amazonDbaEnabled && amazonData?.priceBand === "above_200";
-    amazonOriginWrap.classList.toggle("hidden", !shouldShowOrigin);
+    amazonOriginWrap.classList.toggle("is-hidden", !shouldShowOrigin);
   }
 
   const resultsEl = document.querySelector("#results");
@@ -1603,12 +1607,68 @@ function bind() {
     trackGA4Event(expanded ? "close_incidences" : "open_incidences", { section: "results", marketplace });
   });
 
+  const profitType = $("#profitType");
+  const profitValue = $("#profitValue");
+  const profitValueBRL = $("#profitValueBRL");
+  const profitValuePct = $("#profitValuePct");
+  const profitFieldBRL = $("#profitFieldBRL");
+  const profitFieldPCT = $("#profitFieldPCT");
+
+  const syncProfitValue = () => {
+    if (!profitType || !profitValue) return;
+    const selected = document.querySelector('input[name="profitMode"]:checked')?.value || "brl";
+    profitType.value = selected;
+    if (selected === "pct") {
+      if (profitValuePct && profitValue) profitValuePct.value = profitValue.value || profitValuePct.value;
+      if (profitFieldBRL) profitFieldBRL.classList.add("is-hidden");
+      if (profitFieldPCT) profitFieldPCT.classList.remove("is-hidden");
+      if (profitValuePct) profitValue.value = profitValuePct.value;
+      return;
+    }
+    if (profitValueBRL && profitValue) profitValueBRL.value = profitValue.value || profitValueBRL.value;
+    if (profitFieldPCT) profitFieldPCT.classList.add("is-hidden");
+    if (profitFieldBRL) profitFieldBRL.classList.remove("is-hidden");
+    if (profitValueBRL) profitValue.value = profitValueBRL.value;
+  };
+
+  document.querySelectorAll('input[name="profitMode"]').forEach((input) => {
+    input.addEventListener("change", syncProfitValue);
+  });
+
+  profitValueBRL?.addEventListener("input", () => {
+    if (profitType?.value === "brl" && profitValue) profitValue.value = profitValueBRL.value;
+  });
+
+  profitValuePct?.addEventListener("input", () => {
+    if (profitType?.value === "pct" && profitValue) profitValue.value = profitValuePct.value;
+  });
+
+  syncProfitValue();
+
+  const mlCommissionToggle = $("#mlCommissionToggle");
+  const mlCommissionBox = $("#mlCommissionBox");
+  const applyMlCommissionBox = () => {
+    if (!mlCommissionToggle || !mlCommissionBox) return;
+    mlCommissionBox.classList.toggle("is-hidden", !mlCommissionToggle.checked);
+  };
+  mlCommissionToggle?.addEventListener("change", applyMlCommissionBox);
+  applyMlCommissionBox();
+
+  const sheinCommissionToggle = $("#sheinCommissionToggle");
+  const sheinCommissionBox = $("#sheinCommissionBox");
+  const applySheinCommissionBox = () => {
+    if (!sheinCommissionToggle || !sheinCommissionBox) return;
+    sheinCommissionBox.classList.toggle("is-hidden", !sheinCommissionToggle.checked);
+  };
+  sheinCommissionToggle?.addEventListener("change", applySheinCommissionBox);
+  applySheinCommissionBox();
+
   // Mostrar/esconder box avançadas
   const advToggle = $("#advToggle");
   const advBox = $("#advBox");
   const applyAdvBox = () => {
     if (!advToggle || !advBox) return;
-    advBox.classList.toggle("hidden", !advToggle.checked);
+    advBox.classList.toggle("is-hidden", !advToggle.checked);
   };
   advToggle?.addEventListener("change", applyAdvBox);
   applyAdvBox();
@@ -1618,7 +1678,7 @@ function bind() {
   const affBox = $("#affBox");
   const applyAffBox = () => {
     if (!affToggle || !affBox) return;
-    affBox.classList.toggle("hidden", !affToggle.checked);
+    affBox.classList.toggle("is-hidden", !affToggle.checked);
   };
   affToggle?.addEventListener("change", applyAffBox);
   applyAffBox();
@@ -1628,7 +1688,7 @@ function bind() {
   const wBox = $("#mlWeightBox");
   const applyWBox = () => {
     if (!wToggle || !wBox) return;
-    wBox.classList.toggle("hidden", !wToggle.checked);
+    wBox.classList.toggle("is-hidden", !wToggle.checked);
   };
   wToggle?.addEventListener("change", applyWBox);
   applyWBox();
@@ -1637,7 +1697,7 @@ function bind() {
   const amazonBox = $("#amazonDbaBox");
   const applyAmazonBox = () => {
     if (!amazonToggle || !amazonBox) return;
-    amazonBox.classList.toggle("hidden", !amazonToggle.checked);
+    amazonBox.classList.toggle("is-hidden", !amazonToggle.checked);
   };
   amazonToggle?.addEventListener("change", () => {
     applyAmazonBox();

--- a/index.html
+++ b/index.html
@@ -93,105 +93,172 @@
       <div class="grid">
       <div class="card">
         <div class="card__inner">
-          <h2>Dados básicos</h2>
+          <h2>Precificação do produto</h2>
 
-          <div class="field">
-            <div class="label label-row">
-              <span>Nome do cálculo / produto</span>
-              <button class="info" type="button" aria-label="Info: Nome do cálculo / produto" data-tooltip="Dê um nome para identificar este cálculo no PDF e no salvamento local. Ex: Camiseta Dry Fit Preta.">i</button>
-            </div>
-            <input id="calcName" type="text" maxlength="80" placeholder="Ex: Camiseta Dry Fit Preta" />
-          </div>
-
-          <div class="field">
-            <div class="label label-row">
-              <span>Preço de custo final (compra + impostos) (R$)</span>
-              <button class="info" type="button" aria-label="Info: Preço de custo final (compra + impostos) (R$)" data-tooltip="O custo total do produto antes da venda: compra + impostos/encargos de compra. Ex: preço do fornecedor + ICMS-ST (se houver) + frete de compra, se você já embute no custo.">i</button>
-            </div>
-            <div class="inputWrap">
-              <span class="inputPrefix">R$</span>
-              <input id="cost" type="number" step="0.01" min="0" value="60" />
+          <section class="formBlock">
+            <div class="formBlock__head">
+              <h3>Dados do produto</h3>
+              <p>Preencha apenas os dados essenciais para começar.</p>
             </div>
 
-          </div>
-
-          <div class="field">
-            <div class="label label-row">
-              <span>Alíquota de imposto de venda (%)</span>
-              <button class="info" type="button" aria-label="Info: Alíquota de imposto de venda (%)" data-tooltip="Percentual de imposto que incide na venda (sobre o preço de venda). Use a alíquota efetiva do seu cenário.">i</button>
-            </div>
-            <div class="inputWrap">
-              <input id="tax" type="number" step="0.01" min="0" value="10" />
-              <span class="inputSuffix">%</span>
-            </div>
-
-          </div>
-
-          <div class="row2">
             <div class="field">
               <div class="label label-row">
-                <span id="profitValueLabel">Lucro desejado (valor)</span>
-
-                <button class="info" type="button" aria-label="Info: Lucro desejado (tipo)" data-tooltip="Escolha se o lucro desejado será um valor fixo em reais (R$) ou uma margem em % sobre o preço de venda.">i</button>
+                <span>Nome do cálculo / produto</span>
+                <button class="info" type="button" aria-label="Info: Nome do cálculo / produto" data-tooltip="Dê um nome para identificar este cálculo no PDF e no salvamento local. Ex: Camiseta Dry Fit Preta.">i</button>
               </div>
-              <select id="profitType">
-                <option value="brl">Em R$ (lucro em reais)</option>
+              <input id="calcName" type="text" maxlength="80" placeholder="Ex: Camiseta Dry Fit Preta" />
+            </div>
+
+            <div class="row2">
+              <div class="field">
+                <div class="label label-row">
+                  <span>Custo total (R$)</span>
+                  <button class="info" type="button" aria-label="Info: Custo total (R$)" data-tooltip="O custo total do produto antes da venda: compra + impostos/encargos de compra. Ex: preço do fornecedor + ICMS-ST (se houver) + frete de compra, se você já embute no custo.">i</button>
+                </div>
+                <div class="inputWrap">
+                  <span class="inputPrefix">R$</span>
+                  <input id="cost" type="number" step="0.01" min="0" value="60" />
+                </div>
+              </div>
+
+              <div class="field">
+                <div class="label label-row">
+                  <span>Imposto de venda (%)</span>
+                  <button class="info" type="button" aria-label="Info: Imposto de venda (%)" data-tooltip="Percentual de imposto que incide na venda (sobre o preço de venda). Use a alíquota efetiva do seu cenário.">i</button>
+                </div>
+                <div class="inputWrap">
+                  <input id="tax" type="number" step="0.01" min="0" value="10" />
+                  <span class="inputSuffix">%</span>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <div class="formDivider"></div>
+
+          <section class="formBlock">
+            <div class="formBlock__head">
+              <h3>Meta de lucro</h3>
+              <p>Escolha o modo e informe sua meta.</p>
+            </div>
+
+            <div class="field">
+              <div class="label label-row">
+                <span>Modo da meta</span>
+                <button class="info" type="button" aria-label="Info: Modo da meta" data-tooltip="Escolha se o lucro desejado será um valor fixo em reais (R$) ou uma margem em % sobre o preço de venda.">i</button>
+              </div>
+              <div class="segmented" role="radiogroup" aria-label="Modo da meta de lucro">
+                <label class="segmented__option">
+                  <input type="radio" name="profitMode" value="brl" checked />
+                  <span>Em R$</span>
+                </label>
+                <label class="segmented__option">
+                  <input type="radio" name="profitMode" value="pct" />
+                  <span>Em %</span>
+                </label>
+              </div>
+              <select id="profitType" class="is-hidden" aria-hidden="true" tabindex="-1">
+                <option value="brl" selected>Em R$ (lucro em reais)</option>
                 <option value="pct">Em % (margem sobre o preço)</option>
               </select>
             </div>
 
-            <div class="field">
-              <div class="label label-row">
-                <span>Lucro desejado (valor)</span>
-                <button class="info" type="button" aria-label="Info: Lucro desejado (valor)" data-tooltip="Se estiver em R$: digite o valor do lucro por pedido. Se estiver em %: digite a margem sobre o preço de venda.">i</button>
+            <div id="profitFieldBRL" class="field">
+              <div class="label">Lucro desejado (R$)</div>
+              <div class="inputWrap">
+                <span class="inputPrefix">R$</span>
+                <input id="profitValueBRL" type="number" step="0.01" min="0" value="10" />
               </div>
-              <input id="profitValue" type="number" step="0.01" min="0" value="10" />
-            </div>
-          </div>
-
-          <div class="hint">
-            Regra: custos fixos e lucro em R$ somam no custo. Depois, somamos incidências em % (comissão + imposto [+ lucro% se escolhido] + custos%) e calculamos:
-            <strong>Preço = custo ajustado ÷ (1 − incidências)</strong>.
-          </div>
-
-          <div class="toggle">
-            <label class="check">
-              <input id="mlWeightToggle" type="checkbox" />
-              <span>Informar peso (Mercado Livre + SHEIN)</span>
-            </label>
-            <small>Se ativar, usamos a tabela de custos por faixa de peso + faixa de preço.</small>
-          </div>
-
-          <div id="mlWeightBox" class="row2 hidden">
-            <div class="field">
-              <div class="label label-row">
-                <span>Peso</span>
-                <button class="info" type="button" aria-label="Info: Peso" data-tooltip="Peso do produto para cálculo do custo fixo de envio do Mercado Livre. Se não informar, o sistema assume 500g por padrão.">i</button>
-              </div>
-              <input id="mlWeightValue" type="number" step="0.001" min="0" value="0.5" />
             </div>
 
-            <div class="field">
-              <div class="label label-row">
-                <span>Unidade</span>
-                <button class="info" type="button" aria-label="Info: Unidade" data-tooltip="Escolha gramas (g) ou quilogramas (kg). Ex: 500g = 0,5kg.">i</button>
+            <div id="profitFieldPCT" class="field is-hidden">
+              <div class="label">Lucro desejado (%)</div>
+              <div class="inputWrap">
+                <input id="profitValuePct" type="number" step="0.01" min="0" value="10" />
+                <span class="inputSuffix">%</span>
               </div>
-              <select id="mlWeightUnit">
-                <option value="kg">kg</option>
-                <option value="g">g</option>
+            </div>
+
+            <input id="profitValue" class="is-hidden" type="number" step="0.01" min="0" value="10" tabindex="-1" aria-hidden="true" />
+          </section>
+
+          <details class="formInfoDetails">
+            <summary>Como calculamos?</summary>
+            <p>Regra: custos fixos e lucro em R$ somam no custo. Depois, somamos incidências em % (comissão + imposto [+ lucro% se escolhido] + custos%) e calculamos: <strong>Preço = custo ajustado ÷ (1 − incidências)</strong>.</p>
+          </details>
+
+          <div class="formDivider"></div>
+
+          <section class="formBlock formBlock--actions">
+            <button id="recalc" class="btn btn--primary btn--wide" type="button">Calcular</button>
+
+            <div class="actions actions--stacked">
+              <button id="saveSimulation" class="btn btn--ghost btn--wide" type="button">Salvar simulação</button>
+              <select id="savedSimulations" aria-label="Simulações salvas">
+                <option value="">Simulações salvas</option>
               </select>
             </div>
-          </div>
+          </section>
 
-          <div class="toggle">
-            <label class="check">
-              <input id="amazonDbaToggle" type="checkbox" checked />
-              <span>Incluir Amazon (DBA) no cálculo?</span>
-            </label>
-            <small>Ative para aplicar comissão e tarifa logística DBA por unidade.</small>
-          </div>
+          <details class="formAccordion" id="commissionAccordion">
+            <summary>Personalizar comissões (opcional)</summary>
 
-          <div id="amazonDbaBox" class="cardMini hidden">
+            <div class="toggle">
+              <label class="check">
+                <input id="mlCommissionToggle" type="checkbox" />
+                <span>Definir comissão Mercado Livre</span>
+              </label>
+            </div>
+
+            <div id="mlCommissionBox" class="cardMini is-hidden">
+              <div class="row2">
+                <div class="field">
+                  <div class="label label-row">
+                    <span>ML Clássico (%)</span>
+                    <button class="info" type="button" aria-label="Info: Mercado Livre Clássico (%)" data-tooltip="Por padrão usamos 14%. Você pode editar conforme sua categoria/anúncio.">i</button>
+                  </div>
+                  <input id="mlClassicPct" type="number" step="0.01" min="0" value="14" />
+                </div>
+
+                <div class="field">
+                  <div class="label label-row">
+                    <span>ML Premium (%)</span>
+                    <button class="info" type="button" aria-label="Info: Mercado Livre Premium (%)" data-tooltip="Por padrão usamos 19%. Você pode editar conforme sua categoria/anúncio.">i</button>
+                  </div>
+                  <input id="mlPremiumPct" type="number" step="0.01" min="0" value="19" />
+                </div>
+              </div>
+            </div>
+
+            <div class="toggle">
+              <label class="check">
+                <input id="sheinCommissionToggle" type="checkbox" />
+                <span>Definir comissão SHEIN</span>
+              </label>
+            </div>
+
+            <div id="sheinCommissionBox" class="cardMini is-hidden">
+              <div class="field">
+                <div class="label label-row">
+                  <span>Categoria SHEIN</span>
+                  <button class="info" type="button" aria-label="Info: Categoria SHEIN" data-tooltip="A comissão da SHEIN varia por categoria: Vestuário feminino 20% e demais categorias 18%.">i</button>
+                </div>
+                <select id="sheinCategory">
+                  <option value="other" selected>Demais categorias (18%)</option>
+                  <option value="female">Vestuário feminino (20%)</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="toggle">
+              <label class="check">
+                <input id="amazonDbaToggle" type="checkbox" checked />
+                <span>Incluir Amazon (DBA) no cálculo</span>
+              </label>
+              <small>Ative para aplicar comissão e tarifa logística DBA por unidade.</small>
+            </div>
+
+            <div id="amazonDbaBox" class="cardMini is-hidden">
             <div class="cardMini__header">
               <strong>Amazon (DBA)</strong>
               <span class="pill">Opcional</span>
@@ -208,7 +275,7 @@
             <small>DBA usa o maior entre peso real e cúbico. Aqui usamos o peso informado.</small>
             <small>Se o peso não estiver ativo, calculamos com padrão de 0,5 kg.</small>
 
-            <div id="amazonOriginWrap" class="field hidden">
+            <div id="amazonOriginWrap" class="field is-hidden">
               <div class="label label-row">
                 <span>Origem do envio (DBA)</span>
                 <button class="info" type="button" aria-label="Info: Origem do envio (DBA)" data-tooltip="A origem é exigida no bloco de produtos acima de R$ 200 na tabela DBA da Amazon.">i</button>
@@ -222,53 +289,39 @@
             </div>
           </div>
 
-          <div class="cardMini">
-            <div class="cardMini__header">
-              <strong>Mercado Livre (comissão editável)</strong>
-              <span class="pill">Clássico e Premium</span>
+          </details>
+
+          <details class="formAccordion" id="advancedAccordion">
+            <summary>Ajustes avançados (opcional)</summary>
+
+            <div class="toggle">
+              <label class="check">
+                <input id="mlWeightToggle" type="checkbox" />
+                <span>Informar peso (Mercado Livre + SHEIN)</span>
+              </label>
+              <small>A SHEIN também aplica intermediação de frete por faixa de peso.</small>
             </div>
 
-            <div class="row2">
+            <div id="mlWeightBox" class="row2 is-hidden">
               <div class="field">
                 <div class="label label-row">
-                  <span>Clássico (%)</span>
-                  <button class="info" type="button" aria-label="Info: Mercado Livre Clássico (%)" data-tooltip="Por padrão usamos 14%. Você pode editar conforme sua categoria/anúncio.">i</button>
+                  <span>Peso</span>
+                  <button class="info" type="button" aria-label="Info: Peso" data-tooltip="Peso do produto para cálculo do custo fixo de envio do Mercado Livre. Se não informar, o sistema assume 500g por padrão.">i</button>
                 </div>
-                <input id="mlClassicPct" type="number" step="0.01" min="0" value="14" />
+                <input id="mlWeightValue" type="number" step="0.001" min="0" value="0.5" />
               </div>
 
               <div class="field">
                 <div class="label label-row">
-                  <span>Premium (%)</span>
-                  <button class="info" type="button" aria-label="Info: Mercado Livre Premium (%)" data-tooltip="Por padrão usamos 19%. Você pode editar conforme sua categoria/anúncio.">i</button>
+                  <span>Unidade</span>
+                  <button class="info" type="button" aria-label="Info: Unidade" data-tooltip="Escolha gramas (g) ou quilogramas (kg). Ex: 500g = 0,5kg.">i</button>
                 </div>
-                <input id="mlPremiumPct" type="number" step="0.01" min="0" value="19" />
-              </div>
-            </div>
-
-            <div class="hint">
-              Use este ajuste se sua categoria estiver fora do padrão 14% / 19%.
-            </div>
-          </div>
-
-          <div class="cardMini">
-            <div class="cardMini__header">
-              <strong>Variáveis avançadas</strong>
-              <span class="pill">Opcional</span>
-            </div>
-              <div class="field">
-                <div class="label label-row">
-                  <span>Categoria SHEIN</span>
-                  <button class="info" type="button" aria-label="Info: Categoria SHEIN" data-tooltip="A comissão da SHEIN varia por categoria: Vestuário feminino 20% e demais categorias 18%.">i</button>
-                </div>
-                <select id="sheinCategory">
-                  <option value="other" selected>Demais categorias (18%)</option>
-                  <option value="female">Vestuário feminino (20%)</option>
+                <select id="mlWeightUnit">
+                  <option value="kg">kg</option>
+                  <option value="g">g</option>
                 </select>
-                <small>A SHEIN também aplica uma taxa fixa de intermediação de frete por faixa de peso (calculada pelo peso informado acima; se não informar, assumimos 500g).</small>
               </div>
-
-
+            </div>
 
             <div class="toggle">
               <label class="check">
@@ -278,7 +331,7 @@
               <small>Ads, devolução, custo fixo, DIFAL, PIS, COFINS, outro e afiliados.</small>
             </div>
 
-            <div id="advBox" class="hidden">
+            <div id="advBox" class="is-hidden">
               <div class="advGrid">
                 <div class="advItem">
                   <div class="label label-row">
@@ -394,7 +447,7 @@
                   </label>
                   <small>Incide somente na plataforma correspondente (Shopee, Mercado Livre e TikTok).</small>
 
-                  <div id="affBox" class="affGrid hidden">
+                  <div id="affBox" class="affGrid is-hidden">
                     <div class="field">
                       <div class="label label-row">
                         <span>Afiliados Shopee (%)</span>
@@ -427,16 +480,7 @@
                 Regras: itens em R$ entram como custo fixo (somam no custo). Itens em % entram como incidência (somam nas %).
               </div>
             </div>
-          </div>
-
-          <button id="recalc" class="btn btn--primary btn--wide" type="button">Recalcular</button>
-
-          <div class="actions actions--stacked">
-            <button id="saveSimulation" class="btn btn--ghost btn--wide" type="button">Salvar Simulação</button>
-            <select id="savedSimulations" aria-label="Simulações salvas">
-              <option value="">Simulações salvas</option>
-            </select>
-          </div>
+          </details>
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation
- Tornar o card de “Precificação” mais escaneável e menos poluído, mostrando só o essencial inicialmente (dados + meta de lucro + calcular). 
- Esconder controles de comissão e variáveis avançadas por padrão para reduzir ruído sem alterar nenhum cálculo. 
- Garantir hierarquia visual clara e responsividade impecável em WEB e MOBILE mantendo toda a lógica existente.

### Description
- Reestruturei a UI do card em blocos: `Dados do produto`, `Meta de lucro` e `CTAs`, adicionando mini-accordion `Como calculamos?` e separadores visuais; mantive os IDs internos usados pelo cálculo (`#profitType`, `#profitValue`).
- Adicionei dois accordions opcionais com `<details><summary>`: `Personalizar comissões (opcional)` (ML, SHEIN, Amazon DBA) e `Ajustes avançados (opcional)` (peso e variáveis avançadas), deixando-os fechados por padrão; campos adicionais só aparecem quando o usuário ativa as checkboxes.
- Implementei um controle segmentado para a meta de lucro (modo `Em R$` / `Em %`) que mostra apenas o input correspondente e sincroniza com os campos internos do solver para preservar a lógica sem alterar fórmulas.
- Introduzi a classe utilitária `.is-hidden` e novos estilos (`formBlock`, `formDivider`, `segmented`, `formAccordion`) para hierarquia e responsividade, e atualizei toggles no JavaScript para usar `.is-hidden` preservando comportamentos padrão (ex.: ML usa 14%/19% se não ativado).
- Arquivos alterados: `index.html`, `assets/css/styles.css`, `assets/js/main.js`.

### Testing
- Executado `node --check assets/js/main.js` para verificar sintaxe do JS e o resultado foi sucesso.
- Parse do HTML com `python` (`html.parser.HTMLParser`) para garantir markup válido e o resultado foi sucesso.
- Validação visual gerada via servidor local e captura com Playwright (desktop/mobile) para checar layout responsivo, e as capturas foram produzidas (artefatos gerados durante a execução automatizada).
- Tentativa de `xmllint --html --noout index.html` não foi executada devido à ausência do binário no ambiente (`xmllint: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991bf5c08a48332bf8f5018229ef8ac)