### PR TITLE
feat: adicionar mini-gráfico de composição, tour guiado e calculadora em massa

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -540,3 +540,43 @@ body.theme-dark .resultCard .pill{
 }
 
 #sec-precificacao,#sec-comparar,#sec-lucro,#sec-escala{scroll-margin-top:96px}
+
+/* Premium composition chart */
+.comp{margin-top:12px}
+.comp-bar{display:flex;width:100%;height:10px;border:1px solid var(--stroke);border-radius:999px;overflow:hidden;background:var(--surface-soft);padding:0;cursor:pointer}
+.comp-bar .seg{display:block;height:100%}
+.seg-cost{background:color-mix(in srgb,var(--text) 24%, var(--surface) 76%)}
+.seg-fees{background:color-mix(in srgb,var(--muted) 48%, var(--surface) 52%)}
+.seg-tax{background:color-mix(in srgb,var(--accent) 35%, var(--surface) 65%)}
+.seg-profit{background:color-mix(in srgb,var(--accent) 70%, #fff 30%)}
+.comp-legend{margin-top:6px;font-size:11px;color:var(--muted)}
+.comp-tip{white-space:pre-line;margin-top:8px;padding:8px;border:1px solid var(--stroke);border-radius:10px;background:var(--surface-soft);font-size:12px;color:var(--text)}
+
+/* Guided tour */
+.heroTourBtn{margin-top:14px}
+.tourOverlay{position:fixed;inset:0;background:rgba(15,23,42,.55);z-index:120;display:block}
+.tourPopover{position:fixed;z-index:121;width:min(340px,calc(100vw - 20px));padding:14px;border:1px solid var(--stroke);border-radius:14px;background:var(--surface);box-shadow:var(--shadow-md)}
+.tourTitle{margin:0 0 6px;font-size:16px}
+.tourBody{margin:0 0 12px;font-size:13px;color:var(--muted)}
+.tourActions{display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px}
+.tourTarget{position:relative;z-index:122;outline:2px solid color-mix(in srgb,var(--accent) 72%, #fff 28%);outline-offset:3px;border-radius:10px}
+body.tour-active{overflow:hidden}
+
+/* Bulk section */
+#bulkCsvInput{position:absolute;left:-9999px;opacity:0;pointer-events:none}
+.bulkToolbar{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:8px}
+.bulkUploadBtn{display:inline-flex}
+.bulkHint{margin:8px 0 12px;color:var(--muted);font-size:12px}
+.bulkEditorWrap,.bulkResultsScroll{overflow:auto;border:1px solid var(--stroke);border-radius:12px}
+.bulkEditor,.bulkResults{width:100%;border-collapse:collapse;min-width:680px;background:var(--surface)}
+.bulkEditor th,.bulkEditor td,.bulkResults th,.bulkResults td{padding:10px;border-top:1px solid var(--stroke);text-align:left;font-size:13px}
+.bulkEditor thead th,.bulkResults thead th{position:sticky;top:0;background:var(--surface-soft);z-index:1}
+.bulkResultsWrap{margin-top:14px}
+
+.segmentMenu{grid-template-columns:repeat(5,minmax(0,1fr))}
+#sec-precificacao,#sec-comparar,#sec-lucro,#sec-escala,#sec-bulk{scroll-margin-top:96px}
+
+@media (max-width:768px){
+  .tourPopover{left:10px!important;right:10px!important;bottom:10px!important;top:auto!important;width:auto}
+  .bulkToolbar .btn{flex:1 1 100%}
+}

--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
     <section class="hero">
       <span class="kicker">Simples no início • Completo no avançado</span>
       <h1>Plataforma Oficial de Decisão Financeira para Vendedores de Marketplace</h1>
+      <button id="startTour" class="btn btn--ghost heroTourBtn" type="button">Fazer tour</button>
       <p>Compare marketplaces, entenda seu lucro real e decida o preço com segurança.</p>
       <small class="hero__microcopy">100% gratuito. Sem login.</small>
     </section>
@@ -85,6 +86,7 @@
       <button class="segmentMenu__btn" type="button" data-target="#sec-comparar">Comparar preço</button>
       <button class="segmentMenu__btn" type="button" data-target="#sec-lucro">Lucro atual</button>
       <button class="segmentMenu__btn" type="button" data-target="#sec-escala">Escala</button>
+      <button class="segmentMenu__btn" type="button" data-target="#sec-bulk">Massa</button>
     </nav>
 
     <section id="sec-precificacao" class="sectionCard">
@@ -579,6 +581,42 @@
       </div>
     </section>
 
+
+
+    <section id="sec-bulk" class="sectionCard">
+      <h2>Cálculo em Massa</h2>
+      <p class="sectionMicrocopy">Calcule múltiplos produtos de uma vez usando as configurações globais atuais.</p>
+      <div class="card card--simple">
+        <div class="card__inner">
+          <div class="bulkToolbar">
+            <button id="bulkAddRow" class="btn btn--ghost" type="button">Adicionar linha</button>
+            <label class="btn btn--ghost bulkUploadBtn" for="bulkCsvInput">Importar CSV</label>
+            <input id="bulkCsvInput" type="file" accept=".csv,text/csv" />
+            <button id="bulkCalculate" class="btn btn--primary" type="button">Calcular em massa</button>
+            <button id="bulkExport" class="btn btn--ghost" type="button" disabled>Baixar CSV com resultados</button>
+          </div>
+          <p class="bulkHint">Formato CSV: nome,custo (com ou sem cabeçalho, vírgula ou ponto-e-vírgula).</p>
+
+          <div class="bulkEditorWrap">
+            <table class="bulkEditor" aria-label="Tabela de produtos para cálculo massivo">
+              <thead>
+                <tr><th>Nome</th><th>Custo (R$)</th></tr>
+              </thead>
+              <tbody id="bulkRows"></tbody>
+            </table>
+          </div>
+
+          <div id="bulkResultsWrap" class="bulkResultsWrap is-hidden">
+            <div class="bulkResultsScroll">
+              <table class="bulkResults" aria-label="Resultados do cálculo em massa">
+                <thead id="bulkResultsHead"></thead>
+                <tbody id="bulkResultsBody"></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
 
     <section class="yt-section" id="videos">
       <div class="yt-header">


### PR DESCRIPTION
### Motivation
- Entregar três features premium na UI sem frameworks: (1) visualização da composição do preço por marketplace, (2) tour guiado para novos visitantes e (3) ferramenta de cálculo massivo com import/export CSV.
- Reutilizar a lógica de cálculo existente para evitar divergência nas fórmulas e manter a calculadora atual intacta.
- Garantir boa experiência, acessibilidade e suporte dark/light sem degradar performance.

### Description
- Adiciona um helper `buildComposition(priceIdeal, costTotal, incidencesGroups, profitBRL)` e insere um mini-chart (stacked horizontal) em cada card de resultado com 4 segmentos (custo, taxas, impostos, lucro), tooltip (hover / click mobile) e legenda; estilos em `assets/css/styles.css` e marcação embutida via `resultCardHTML` em `assets/js/main.js`.
- Implementa tracking GA4: dispara `view_composition` uma vez por sessão ao renderizar cards com gráficos e `composition_click` quando o usuário interage com o gráfico/tooltip.
- Cria módulo `Tour` em `assets/js/main.js` com API `{ start(), next(), prev(), stop(), complete() }`, DOM dinâmico (overlay + popover), destaque do elemento alvo, controles (Próximo/Voltar/Pular/Concluir), ESC para fechar, persistência em `localStorage` (`TOUR_DONE` / `TOUR_SKIPPED`) e eventos GA4 (`tour_start`, `tour_step`, `tour_complete`, `tour_skip`), além de botão manual `#startTour` no Hero e auto-start quando apropriado.
- Cria módulo `Bulk` em `assets/js/main.js` com editor (10 linhas iniciais), botão “Adicionar linha”, import CSV tolerante (vírgula / ponto-e-vírgula, com/sem cabeçalho, limpeza de R$ e vírgula decimal), reuso da lógica central via `computeForAllMarketplaces(inputState)` para calcular por marketplace, render da tabela de resultados e export CSV; adiciona seção `#sec-bulk` e entrada no menu de abas.
- Ajustes de bindings e navegação: limita auto-recalcs a inputs relevantes, adiciona `#sec-bulk` a `bindSmoothScroll`/segment menu, e integra `bindTourAndBulk()` no bootstrap da aplicação.

### Testing
- Rodado `node --check assets/js/main.js && node --check assets/js/pdf-export.js` para validação estática de sintaxe JavaScript e ambos passaram com sucesso.
- Iniciado servidor local com `python -m http.server 4173` e carregamento manual da página foi verificado (assets servidos corretamente), incluindo clique em `#recalc` e navegação até a nova seção `#sec-bulk` para checagem visual manual.
- Tentativa automatizada com Playwright para capturar screenshot falhou no ambiente por crash/timeout do browser container, portanto as verificações visuais automatizadas não geraram artifacts (este é um problema do ambiente de execução, não do código).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991cab1555c83328620450250ec2129)