### PR TITLE
feat: pro mode UX and copy improvements

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -102,6 +102,20 @@ input:hover,select:hover{border-color:#b8c5d7}
 .formAccordion[open] summary::after{transform:rotate(180deg)}
 .formAccordion > :not(summary){padding:0 16px 16px}
 
+.pro-mode{margin-top:18px;padding:20px;border:1px solid #d9d5ff;border-radius:18px;background:linear-gradient(180deg,#ffffff,#f7f5ff);box-shadow:0 10px 30px rgba(76,29,149,.08)}
+.pro-mode__header h3{margin:0;font-size:22px;letter-spacing:-.01em}
+.pro-mode__subtitle{margin:6px 0 0;font-weight:600;color:#4338ca}
+.pro-mode__microcopy{margin:10px 0 0;color:#475569;line-height:1.45}
+.pro-mode__chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:12px}
+.pro-chip{display:inline-flex;align-items:center;padding:6px 10px;border-radius:999px;background:#eef2ff;border:1px solid #c7d2fe;color:#3730a3;font-size:12px;font-weight:700}
+.pro-mode__toggle{margin-top:14px;width:100%;padding:12px 14px;border:1px solid #c4b5fd;border-radius:12px;background:#fff;font-weight:700;color:#4338ca;cursor:pointer;transition:all .25s ease}
+.pro-mode__toggle:hover{transform:translateY(-1px);box-shadow:0 8px 18px rgba(76,29,149,.14)}
+.pro-mode__toggle.is-on{background:linear-gradient(180deg,#4f46e5,#4338ca);color:#fff;border-color:#4338ca}
+.pro-mode__content{max-height:0;overflow:hidden;opacity:0;transition:max-height .35s ease,opacity .25s ease;margin-top:0}
+.pro-mode__content.is-open{max-height:2200px;opacity:1;margin-top:14px}
+.pro-mode__insight{margin:14px 0 0;font-size:13px;color:#4c1d95;font-weight:600}
+.pro-mode-result-badge{margin:0 0 12px;padding:10px 12px;border-radius:12px;background:#ecfeff;border:1px solid #67e8f9;color:#155e75;font-weight:700}
+
 .cardMini{margin-top:14px;border-radius:14px;border:1px solid var(--stroke);background:#fff;padding:14px}
 .cardMini__header{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px}
 .pill{padding:5px 9px;border-radius:999px;background:var(--accent-soft);color:var(--accent);font-size:11px;font-weight:700;border:1px solid #bcefeb}
@@ -311,6 +325,10 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
   .segmentMenu__btn{flex:0 0 auto;scroll-snap-align:start;white-space:nowrap}
   .sectionCard{padding:16px}
   .grid,.row2,.affGrid,.advGrid,.stickySummary__actions,.shareBox__actions,.actions,.currentPriceByMarketplace{grid-template-columns:1fr}
+  .pro-mode{padding:16px}
+  .pro-mode__header h3{font-size:19px}
+  .pro-mode__chips{gap:6px}
+  .pro-chip{font-size:11px}
   .card__inner{padding:16px}
   .cardHeader{flex-wrap:wrap}
   .cardHeader .pill{margin-top:2px}

--- a/index.html
+++ b/index.html
@@ -287,202 +287,14 @@
 
           </details>
 
-          <details class="formAccordion" id="advancedAccordion">
-            <summary>Ajustes avançados (opcional)</summary>
-
-            <div class="toggle">
-              <label class="check">
-                <input id="mlWeightToggle" type="checkbox" />
-                <span>Informar peso (Mercado Livre + SHEIN)</span>
-              </label>
-              <small>A SHEIN também aplica intermediação de frete por faixa de peso.</small>
-            </div>
-
-            <div id="mlWeightBox" class="row2 is-hidden">
-              <div class="field">
-                <div class="label label-row">
-                  <span>Peso</span>
-                  <button class="info" type="button" aria-label="Info: Peso" data-tooltip="Peso do produto para cálculo do custo fixo de envio do Mercado Livre. Se não informar, o sistema assume 500g por padrão.">i</button>
-                </div>
-                <input id="mlWeightValue" type="number" step="0.001" min="0" value="0.5" />
-              </div>
-
-              <div class="field">
-                <div class="label label-row">
-                  <span>Unidade</span>
-                  <button class="info" type="button" aria-label="Info: Unidade" data-tooltip="Escolha gramas (g) ou quilogramas (kg). Ex: 500g = 0,5kg.">i</button>
-                </div>
-                <select id="mlWeightUnit">
-                  <option value="kg">kg</option>
-                  <option value="g">g</option>
-                </select>
-              </div>
-            </div>
-
-            <div class="toggle">
-              <label class="check">
-                <input id="advToggle" type="checkbox" />
-                <span>Aplicar variáveis avançadas</span>
-              </label>
-              <small>Ads, devolução, custo fixo, DIFAL, PIS, COFINS, outro e afiliados.</small>
-            </div>
-
-            <div id="advBox" class="is-hidden">
-              <div class="advGrid">
-                <div class="advItem">
-                  <div class="label label-row">
-                    <label class="check">
-                      <input id="adsToggle" type="checkbox" />
-                      <span>Custo de Ads</span>
-                    </label>
-                    <button
-                      class="info"
-                      type="button"
-                      aria-label="Info: Custo de Ads"
-                      data-tooltip="Informe quanto do seu faturamento é gasto em ads (%). Ex: se a cada R$ 100 vendidos você gasta R$ 8 em anúncios, preencha 8%."
-                    >i</button>
-                  </div>
-
-                  <div class="row2">
-                    <select id="adsType">
-                      <option value="pct">Em %</option>
-                      <option value="brl">Em R$</option>
-                    </select>
-                    <input id="adsValue" type="number" step="0.01" min="0" value="0" />
-                  </div>
-                </div>
-
-                <div class="advItem">
-                  <div class="label label-row">
-                    <label class="check">
-                      <input id="returnToggle" type="checkbox" />
-                      <span>Custo de devolução</span>
-                    </label>
-                    <button
-                      class="info"
-                      type="button"
-                      aria-label="Info: Custo de devolução"
-                      data-tooltip="Informe quanto do seu faturamento é gasto com devoluções (%). Considere trocas, reenvios, estornos e logística reversa. Ex: se perde R$ 3 a cada R$ 100 vendidos, preencha 3%."
-                    >i</button>
-                  </div>
-
-                  <div class="row2">
-                    <select id="returnType">
-                      <option value="pct">Em %</option>
-                      <option value="brl">Em R$</option>
-                    </select>
-                    <input id="returnValue" type="number" step="0.01" min="0" value="0" />
-                  </div>
-                </div>
-
-                <div class="advItem">
-                  <div class="label label-row">
-                    <label class="check">
-                      <input id="costFixedToggle" type="checkbox" />
-                      <span>Custo fixo</span>
-                    </label>
-                    <button
-                      class="info"
-                      type="button"
-                      aria-label="Info: Custo fixo"
-                      data-tooltip="Custos fixos que incidem sobre o preço de venda. Pode ser um percentual (%) ou um valor fixo em reais (R$). Ex: 5% de custos operacionais ou R$ 10 por produto."
-                    >i</button>
-                  </div>
-
-                  <div class="row2">
-                    <select id="costFixedType">
-                      <option value="pct">Em %</option>
-                      <option value="brl">Em R$</option>
-                    </select>
-                    <input id="costFixedValue" type="number" step="0.01" min="0" value="0" />
-                  </div>
-                </div>
-
-                <div class="advItem">
-                  <label class="check">
-                    <input id="difalToggle" type="checkbox" />
-                    <span>DIFAL (%)</span>
-                  </label>
-                  <input id="difalValue" type="number" step="0.01" min="0" value="0" />
-                </div>
-
-                <div class="advItem">
-                  <label class="check">
-                    <input id="pisToggle" type="checkbox" />
-                    <span>PIS (%)</span>
-                  </label>
-                  <input id="pisValue" type="number" step="0.01" min="0" value="0" />
-                </div>
-
-                <div class="advItem">
-                  <label class="check">
-                    <input id="cofinsToggle" type="checkbox" />
-                    <span>COFINS (%)</span>
-                  </label>
-                  <input id="cofinsValue" type="number" step="0.01" min="0" value="0" />
-                </div>
-
-                <div class="advItem">
-                  <label class="check">
-                    <input id="otherToggle" type="checkbox" />
-                    <span>Outro</span>
-                  </label>
-                  <div class="row2">
-                    <select id="otherType">
-                      <option value="pct">Em %</option>
-                      <option value="brl">Em R$</option>
-                    </select>
-                    <input id="otherValue" type="number" step="0.01" min="0" value="0" />
-                  </div>
-                </div>
-
-                <div class="advItem advItem--wide">
-                  <label class="check">
-                    <input id="affToggle" type="checkbox" />
-                    <span>Afiliados</span>
-                  </label>
-                  <small>Incide somente na plataforma correspondente (Shopee, Mercado Livre e TikTok).</small>
-
-                  <div id="affBox" class="affGrid is-hidden">
-                    <div class="field">
-                      <div class="label label-row">
-                        <span>Afiliados Shopee (%)</span>
-                        <button class="info" type="button" aria-label="Info: Afiliados Shopee (%)" data-tooltip="Percentual pago ao afiliado dentro da Shopee. Incide só no cálculo da Shopee.">i</button>
-                      </div>
-                      <input id="affShopee" type="number" step="0.01" min="0" value="0" />
-                    </div>
-
-                    <div class="field">
-                      <div class="label label-row">
-                        <span>Afiliados Mercado Livre (%)</span>
-                        <button class="info" type="button" aria-label="Info: Afiliados Mercado Livre (%)" data-tooltip="Percentual de custo de afiliados/CPA do Mercado Livre. Incide só no cálculo do ML (Clássico e Premium).">i</button>
-                      </div>
-                      <input id="affML" type="number" step="0.01" min="0" value="0" />
-                    </div>
-
-                    <div class="field">
-                      <div class="label label-row">
-                        <span>Afiliados TikTok (%)</span>
-                        <button class="info" type="button" aria-label="Info: Afiliados TikTok (%)" data-tooltip="Percentual pago ao afiliado dentro do TikTok Shop. Incide só no cálculo do TikTok.">i</button>
-                      </div>
-                      <input id="affTikTok" type="number" step="0.01" min="0" value="0" />
-                    </div>
-                  </div>
-
-                </div>
-              </div>
-
-              <div class="hint">
-                Regras: itens em R$ entram como custo fixo (somam no custo). Itens em % entram como incidência (somam nas %).
-              </div>
-            </div>
-          </details>
+          
         </div>
       </div>
 
       <div class="card stickyResultsCard">
         <div class="card__inner">
           <h2>Resultados</h2>
+          <div id="proModeBadgeSlot"></div>
           <div id="rankingInsights" class="rankingInsights" aria-live="polite"></div>
           <div id="results" class="resultList"></div>
 
@@ -516,6 +328,214 @@
         </div>
       </div>
       </div>
+
+      <section class="pro-mode" aria-labelledby="proModeTitle">
+        <div class="pro-mode__header">
+          <h3 id="proModeTitle">💎 Modo Profissional (recomendado)</h3>
+          <p class="pro-mode__subtitle">Inclua taxas e detalhes que mudam seu lucro de verdade.</p>
+          <p class="pro-mode__microcopy">Evite precificar no “olhômetro”.<br />Ative para considerar impostos, taxas extras e regras específicas do marketplace.</p>
+
+          <div class="pro-mode__chips" aria-label="Itens cobertos no modo profissional">
+            <span class="pro-chip">Impostos</span>
+            <span class="pro-chip">Taxas do marketplace</span>
+            <span class="pro-chip">Frete / Peso</span>
+            <span class="pro-chip">Custos extras</span>
+            <span class="pro-chip">Antecipação / recebimento</span>
+          </div>
+
+          <button
+            id="proModeToggle"
+            class="pro-mode__toggle"
+            type="button"
+            aria-pressed="false"
+            aria-expanded="false"
+            aria-controls="proModeContent"
+          >
+            Ativar Modo Profissional
+          </button>
+        </div>
+
+        <div id="proModeContent" class="pro-mode__content" aria-hidden="true">
+          <div class="toggle">
+            <label class="check">
+              <input id="mlWeightToggle" type="checkbox" />
+              <span>Informar peso (Mercado Livre + SHEIN)</span>
+            </label>
+            <small>A SHEIN também aplica intermediação de frete por faixa de peso.</small>
+          </div>
+
+          <div id="mlWeightBox" class="row2 is-hidden">
+            <div class="field">
+              <div class="label label-row">
+                <span>Peso</span>
+                <button class="info" type="button" aria-label="Info: Peso" data-tooltip="Peso do produto para cálculo do custo fixo de envio do Mercado Livre. Se não informar, o sistema assume 500g por padrão.">i</button>
+              </div>
+              <input id="mlWeightValue" type="number" step="0.001" min="0" value="0.5" />
+            </div>
+
+            <div class="field">
+              <div class="label label-row">
+                <span>Unidade</span>
+                <button class="info" type="button" aria-label="Info: Unidade" data-tooltip="Escolha gramas (g) ou quilogramas (kg). Ex: 500g = 0,5kg.">i</button>
+              </div>
+              <select id="mlWeightUnit">
+                <option value="kg">kg</option>
+                <option value="g">g</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="toggle">
+            <label class="check">
+              <input id="advToggle" type="checkbox" />
+              <span>Aplicar variáveis avançadas</span>
+            </label>
+            <small>Ads, devolução, custo fixo, DIFAL, PIS, COFINS, outro e afiliados.</small>
+          </div>
+
+          <div id="advBox" class="is-hidden">
+            <div class="advGrid">
+              <div class="advItem">
+                <div class="label label-row">
+                  <label class="check">
+                    <input id="adsToggle" type="checkbox" />
+                    <span>Custo de Ads</span>
+                  </label>
+                  <button
+                    class="info"
+                    type="button"
+                    aria-label="Info: Custo de Ads"
+                    data-tooltip="Informe quanto do seu faturamento é gasto em ads (%). Ex: se a cada R$ 100 vendidos você gasta R$ 8 em anúncios, preencha 8%."
+                  >i</button>
+                </div>
+
+                <div class="row2">
+                  <select id="adsType">
+                    <option value="pct">Em %</option>
+                    <option value="brl">Em R$</option>
+                  </select>
+                  <input id="adsValue" type="number" step="0.01" min="0" value="0" />
+                </div>
+              </div>
+
+              <div class="advItem">
+                <div class="label label-row">
+                  <label class="check">
+                    <input id="returnToggle" type="checkbox" />
+                    <span>Custo de devolução</span>
+                  </label>
+                  <button
+                    class="info"
+                    type="button"
+                    aria-label="Info: Custo de devolução"
+                    data-tooltip="Estimativa de devolução/troca. Pode ser percentual do faturamento ou valor fixo por venda."
+                  >i</button>
+                </div>
+
+                <div class="row2">
+                  <select id="returnType">
+                    <option value="pct">Em %</option>
+                    <option value="brl">Em R$</option>
+                  </select>
+                  <input id="returnValue" type="number" step="0.01" min="0" value="0" />
+                </div>
+              </div>
+
+              <div class="advItem">
+                <label class="check">
+                  <input id="costFixedToggle" type="checkbox" />
+                  <span>Custo fixo</span>
+                </label>
+                <div class="row2">
+                  <select id="costFixedType">
+                    <option value="brl" selected>Em R$</option>
+                    <option value="pct">Em %</option>
+                  </select>
+                  <input id="costFixedValue" type="number" step="0.01" min="0" value="0" />
+                </div>
+              </div>
+
+              <div class="advItem">
+                <label class="check">
+                  <input id="difalToggle" type="checkbox" />
+                  <span>DIFAL (%)</span>
+                </label>
+                <input id="difalValue" type="number" step="0.01" min="0" value="0" />
+              </div>
+
+              <div class="advItem">
+                <label class="check">
+                  <input id="pisToggle" type="checkbox" />
+                  <span>PIS (%)</span>
+                </label>
+                <input id="pisValue" type="number" step="0.01" min="0" value="0" />
+              </div>
+
+              <div class="advItem">
+                <label class="check">
+                  <input id="cofinsToggle" type="checkbox" />
+                  <span>COFINS (%)</span>
+                </label>
+                <input id="cofinsValue" type="number" step="0.01" min="0" value="0" />
+              </div>
+
+              <div class="advItem">
+                <label class="check">
+                  <input id="otherToggle" type="checkbox" />
+                  <span>Outro</span>
+                </label>
+                <div class="row2">
+                  <select id="otherType">
+                    <option value="pct">Em %</option>
+                    <option value="brl">Em R$</option>
+                  </select>
+                  <input id="otherValue" type="number" step="0.01" min="0" value="0" />
+                </div>
+              </div>
+
+              <div class="advItem advItem--wide">
+                <label class="check">
+                  <input id="affToggle" type="checkbox" />
+                  <span>Afiliados</span>
+                </label>
+                <small>Incide somente na plataforma correspondente (Shopee, Mercado Livre e TikTok).</small>
+
+                <div id="affBox" class="affGrid is-hidden">
+                  <div class="field">
+                    <div class="label label-row">
+                      <span>Afiliados Shopee (%)</span>
+                      <button class="info" type="button" aria-label="Info: Afiliados Shopee (%)" data-tooltip="Percentual pago ao afiliado dentro da Shopee. Incide só no cálculo da Shopee.">i</button>
+                    </div>
+                    <input id="affShopee" type="number" step="0.01" min="0" value="0" />
+                  </div>
+
+                  <div class="field">
+                    <div class="label label-row">
+                      <span>Afiliados Mercado Livre (%)</span>
+                      <button class="info" type="button" aria-label="Info: Afiliados Mercado Livre (%)" data-tooltip="Percentual de custo de afiliados/CPA do Mercado Livre. Incide só no cálculo do ML (Clássico e Premium).">i</button>
+                    </div>
+                    <input id="affML" type="number" step="0.01" min="0" value="0" />
+                  </div>
+
+                  <div class="field">
+                    <div class="label label-row">
+                      <span>Afiliados TikTok (%)</span>
+                      <button class="info" type="button" aria-label="Info: Afiliados TikTok (%)" data-tooltip="Percentual pago ao afiliado dentro do TikTok Shop. Incide só no cálculo do TikTok.">i</button>
+                    </div>
+                    <input id="affTikTok" type="number" step="0.01" min="0" value="0" />
+                  </div>
+                </div>
+
+              </div>
+            </div>
+
+            <div class="hint">
+              Regras: itens em R$ entram como custo fixo (somam no custo). Itens em % entram como incidência (somam nas %).
+            </div>
+          </div>
+        </div>
+        <p id="proModeInsight" class="pro-mode__insight">Dica: ajustes profissionais podem mudar seu lucro final.</p>
+      </section>
     </section>
 
     <section id="sec-comparar" class="sectionCard">


### PR DESCRIPTION
### Motivation
- Melhorar descoberta e adoção das “Variáveis avançadas” tornando-as mais visíveis e com copy orientada a lucro real.
- Entregar um fluxo que preserve a experiência simples (resultados rápidos) e permita ativar um modo premium que expanda ajustes avançados.
- Aumentar confiança com selo/insight quando a simulação estiver detalhada.

### Description
- Adicionado o bloco `section.pro-mode` em `index.html` abaixo da área de resultados contendo título, subtítulo, microcopy, chips e o toggle com os rótulos solicitados; os campos avançados existentes foram re-encapsulados sem duplicação (arquivos afetados: `index.html`).
- Implementado estado `PRO_MODE_ENABLED` com persistência em `localStorage`, funções `initProMode`, `applyProModeState` e `renderProModeBadgeAndInsight` em `assets/js/main.js`, aplicando classe `.pro-enabled` e atualizando atributos de acessibilidade (`aria-pressed`, `aria-expanded`, `aria-hidden`).
- Integração com o cálculo: `getCalculationConfig` e `recalc` agora respeitam `PRO_MODE_ENABLED` (variáveis avançadas e peso só são aplicadas quando ativo), sem alterar fórmulas de cálculo, e o recálculo é disparado ao ligar/desligar o modo.
- Adicionadas melhorias de estilo e animação (accordion suave, botão ON/OFF, chips pill, selo nos resultados) e ajustes mobile em `assets/css/styles.css` para evitar quebras e fazer chips quebrarem em linhas.
- Atualizado passo do tour para apontar `#proModeToggle` em vez de `#advancedAccordion` e inserido slot `#proModeBadgeSlot` para exibir o selo de simulação detalhada.

### Testing
- Executado `node --check assets/js/main.js` e a verificação retornou sem erros (sucesso).
- Tentativa de rodar servidor local (`python -m http.server`) e captura via Playwright foi feita, porém a renderização/screenshot falharam por restrições do ambiente (problemas de processo/porta no runner), portanto testes end-to-end não foram concluídos (falha por ambiente).
- Verificações manuais de consistência de IDs e inclusão de campos/troca no código foram realizadas e `git commit` foi criado com as mudanças.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69960793ba2c8332b17625b8a60a13de)