### PR TITLE
feat: top CTA scroll to pro mode

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -114,7 +114,14 @@ input:hover,select:hover{border-color:#b8c5d7}
 .pro-mode__content{max-height:0;overflow:hidden;opacity:0;transition:max-height .35s ease,opacity .25s ease;margin-top:0}
 .pro-mode__content.is-open{max-height:2200px;opacity:1;margin-top:14px}
 .pro-mode__insight{margin:14px 0 0;font-size:13px;color:#4c1d95;font-weight:600}
+.pro-mode.pro-attention{animation:proPulse 1.4s ease}
 .pro-mode-result-badge{margin:0 0 12px;padding:10px 12px;border-radius:12px;background:#ecfeff;border:1px solid #67e8f9;color:#155e75;font-weight:700}
+
+@keyframes proPulse{
+  0%{box-shadow:0 10px 30px rgba(76,29,149,.08),0 0 0 0 rgba(99,102,241,0);outline:2px solid transparent;outline-offset:2px}
+  30%{box-shadow:0 14px 34px rgba(76,29,149,.16),0 0 0 6px rgba(99,102,241,.18);outline:2px solid rgba(99,102,241,.42)}
+  100%{box-shadow:0 10px 30px rgba(76,29,149,.08),0 0 0 0 rgba(99,102,241,0);outline:2px solid transparent;outline-offset:2px}
+}
 
 .cardMini{margin-top:14px;border-radius:14px;border:1px solid var(--stroke);background:#fff;padding:14px}
 .cardMini__header{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px}
@@ -278,7 +285,11 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
 
 .rankingInsights{margin:0 0 12px;padding:12px;border:1px solid var(--stroke);border-radius:12px;background:var(--surface-soft);display:grid;gap:6px}
 .actions--stacked{margin-top:0;display:grid;grid-template-columns:1fr;gap:10px}
+
 .formActionsSecondary .btn--ghost{border-color:#cbd5e1;background:#f8fafc;font-weight:600}
+.btn--pro-cta{border-color:#c7d2fe;background:linear-gradient(180deg,#f8faff,#eef2ff);color:#3730a3;font-weight:700}
+.btn--pro-cta:hover{border-color:#a5b4fc;box-shadow:0 8px 18px rgba(67,56,202,.14);transform:translateY(-1px)}
+.btnProModeGo__microcopy{display:block;margin-top:-4px;color:#64748b;font-size:12px;line-height:1.35}
 
 .marketplaceCard .cardHeader{padding:14px 16px;margin:-1px -1px 10px;border-radius:16px 16px 0 0;border-bottom:1px solid var(--stroke)}
 .marketplaceCard.marketplace-shopee .cardHeader{background:rgba(238,77,45,.08)}
@@ -329,6 +340,7 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
   .pro-mode__header h3{font-size:19px}
   .pro-mode__chips{gap:6px}
   .pro-chip{font-size:11px}
+  .btnProModeGo__microcopy{margin-top:0}
   .card__inner{padding:16px}
   .cardHeader{flex-wrap:wrap}
   .cardHeader .pill{margin-top:2px}
@@ -610,4 +622,10 @@ body.tour-active{overflow:hidden}
 @media (max-width:768px){
   .tourPopover{left:10px!important;right:10px!important;bottom:10px!important;top:auto!important;width:auto}
   .bulkToolbar .btn{flex:1 1 100%}
+}
+
+
+@media (prefers-reduced-motion: reduce){
+  html,body{scroll-behavior:auto}
+  .pro-mode.pro-attention{animation:none}
 }

--- a/index.html
+++ b/index.html
@@ -188,6 +188,9 @@
           <section class="formBlock formBlock--actions">
             <button id="recalc" class="btn btn--primary btn--wide" type="button">Calcular</button>
 
+            <button id="btnProModeGo" class="btn btn--ghost btn--wide btn--pro-cta" type="button">Calcular no Modo Profissional</button>
+            <small class="btnProModeGo__microcopy">Inclui taxas e detalhes que mudam seu lucro real.</small>
+
             <div class="actions actions--stacked formActionsSecondary">
               <button id="saveSimulation" class="btn btn--ghost btn--wide" type="button">Salvar simulação</button>
               <select id="savedSimulations" aria-label="Simulações salvas">
@@ -329,7 +332,7 @@
       </div>
       </div>
 
-      <section class="pro-mode" aria-labelledby="proModeTitle">
+      <section id="pro-mode" class="pro-mode" aria-labelledby="proModeTitle">
         <div class="pro-mode__header">
           <h3 id="proModeTitle">💎 Modo Profissional (recomendado)</h3>
           <p class="pro-mode__subtitle">Inclua taxas e detalhes que mudam seu lucro de verdade.</p>


### PR DESCRIPTION
### Motivation
- Facilitar descoberta do bloco “💎 Modo Profissional” que estava muito abaixo na página adicionando um CTA no card principal que leve o usuário diretamente ao bloco.
- UX: abrir o accordion do modo profissional sem ativar automaticamente o modo, focar o toggle quando estiver OFF e destacar temporariamente o bloco para facilitar identificação.
- Respeitar acessibilidade (prefers-reduced-motion) e não quebrar mobile/desktop nem gerar erros se GA4 não estiver disponível.

### Description
- Adicionado botão secundário no card de inputs com `id="btnProModeGo"` e microtexto explicativo em `index.html` e adicionado `id="pro-mode"` no container do modo profissional para ancoragem estável.
- Implementada função `scrollToProMode({ openAccordion = true })` em `assets/js/main.js` que calcula offset do header, faz scroll (ou `auto` se `prefers-reduced-motion`), abre o conteúdo do accordion (`#proModeContent`) sem ativar `PRO_MODE_ENABLED`, foca o toggle (`#proModeToggle`) quando PRO estiver OFF, aplica a classe temporária `.pro-attention` e emite eventos GA4 `pro_mode_cta_click` e `pro_mode_scrolled`.
- Ligado o clique do novo botão ao `scrollToProMode` em `assets/js/main.js` e adicionados estilos em `assets/css/styles.css` para o CTA (`.btn--pro-cta`), microcopy e a animação de destaque (`.pro-attention` + `@keyframes proPulse`) com fallback em `@media (prefers-reduced-motion: reduce)`.

### Testing
- Executei verificação estática do JavaScript com `node --check assets/js/main.js`, que retornou sem erros.
- Inspeções estáticas e diffs (`rg` / `git diff`) confirmaram a presença das alterações em `index.html`, `assets/js/main.js` e `assets/css/styles.css`.
- Tentativas de executar um servidor local (`python -m http.server`) e capturas via Playwright foram feitas para screenshots, porém enfrentaram instabilidade/timeouts no ambiente automatizado, então não houve captura visual validada pelo CI aqui; a lógica de scroll/abrir/foco foi verificada por inspeção do código.
- GA4 tracking foi instrumentado usando a função existente `trackGA4Event` que falha silenciosamente se `gtag` não existir, evitando erros em ambientes sem GA4.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699614d5a15c8332a3ea490e42ff9a46)