### PR TITLE
Refatora resultados por marketplace para accordions e destaca PREÇO IDEAL

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -107,6 +107,7 @@ input:hover,select:hover{border-color:#b8c5d7}
 .formAccordion summary::after{content:"▾";font-size:14px;color:var(--muted);transition:transform .2s ease}
 .formAccordion[open] summary::after{transform:rotate(180deg)}
 .formAccordion > :not(summary){padding:0 16px 16px}
+.formAccordion__intro{margin:0 0 10px;color:var(--muted);font-size:12px;line-height:1.4}
 
 .pro-mode{margin-top:18px;padding:20px;border:1px solid #d9d5ff;border-radius:18px;background:linear-gradient(180deg,#ffffff,#f7f5ff);box-shadow:0 10px 30px rgba(76,29,149,.08)}
 .pro-mode__header h3{margin:0;font-size:22px;letter-spacing:-.01em}
@@ -137,6 +138,20 @@ input:hover,select:hover{border-color:#b8c5d7}
 .advItem--wide{grid-column:1/-1}
 .affGrid{display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px;margin-top:10px}
 
+.resultAccordion{overflow:hidden;padding:0}
+.resultAccordion summary{list-style:none;cursor:pointer;padding:14px 16px}
+.resultAccordion summary::-webkit-details-marker{display:none}
+.resultAccordion__summary{display:grid;gap:10px}
+.resultAccordion__header{margin-bottom:0}
+.resultAccordion__quickStats{display:flex;justify-content:space-between;gap:10px;color:var(--muted);font-size:12px}
+.resultAccordion__quickStats strong{display:block;color:var(--text);font-size:14px;font-weight:700}
+.resultAccordion__heroBox{margin-bottom:0}
+.resultAccordion__body{padding:0 16px 16px;border-top:1px solid var(--stroke)}
+.resultAccordion .heroLabel{font-size:14px;letter-spacing:.1em;font-weight:800}
+.resultAccordion .heroValue{font-size:clamp(36px,4.6vw,50px);font-weight:900}
+.resultAccordion .resultGrid--support .k{font-size:10px;font-weight:600;opacity:.85}
+.resultAccordion .resultGrid--support .v{font-size:13px;font-weight:600}
+.resultAccordion[open] .resultAccordion__summary{padding-bottom:2px}
 .resultList,.marketCompareList{display:flex;flex-direction:column;gap:12px}
 .resultList .card,
 .marketCompareList .card{
@@ -355,6 +370,9 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
   .cardHeader .pill{margin-top:2px}
   .resultGrid .k{font-size:11px}
   .resultGrid .v{font-size:13px}
+  .resultAccordion summary{padding:12px}
+  .resultAccordion__body{padding:0 12px 12px}
+  .resultAccordion__quickStats{display:grid;grid-template-columns:1fr 1fr}
   .stickySummary{left:10px;right:10px;bottom:10px;width:auto;max-height:none;overflow:visible;padding:12px 12px calc(12px + env(safe-area-inset-bottom));border-radius:16px 16px 12px 12px}
   .stickySummary__content{max-height:none;overflow:visible;padding-right:0}
   .stickyOpen{right:10px;bottom:14px}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -868,56 +868,65 @@ function resultCardHTML(
     : "";
 
   const accordionId = `incidence-${title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+  const cardId = `market-card-${title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
   return `
-  <div class="card marketplaceCard resultCard ${options.marketplaceClass || ""}">
-    <div class="cardHeader">
-      <div class="cardTitleWrap">
-        <span class="cardIcon" aria-hidden="true">${options.marketplaceIcon || "🛒"}</span>
-        <div class="cardTitle">${title}</div>
+  <details class="card marketplaceCard resultCard resultAccordion ${options.marketplaceClass || ""}" id="${cardId}">
+    <summary class="resultAccordion__summary">
+      <div class="cardHeader resultAccordion__header">
+        <div class="cardTitleWrap">
+          <span class="cardIcon" aria-hidden="true">${options.marketplaceIcon || "🛒"}</span>
+          <div class="cardTitle">${title}</div>
+        </div>
+        <div class="pill">${pill}</div>
       </div>
-      <div class="pill">${pill}</div>
-    </div>
 
-    ${shopeeToggleHTML}
+      <div class="heroBox resultAccordion__heroBox">
+        <div class="heroLabel">PREÇO IDEAL</div>
+        <div class="heroValue">${price}</div>
+      </div>
 
-    <div class="heroBox">
-      <div class="heroLabel">PREÇO IDEAL</div>
-      <div class="heroValue">${price}</div>
-    </div>
+      <div class="resultAccordion__quickStats" aria-hidden="true">
+        <div>Você recebe <strong>${received}</strong></div>
+        <div>Incidências <strong>${incidencesPct}</strong></div>
+      </div>
+    </summary>
 
-    <!-- RESUMO (sem repetir embaixo) -->
-    <div class="resultGrid">
-      <div class="k">VOCÊ RECEBE</div><div class="v">${received}</div>
-      <div class="k">LUCRO</div><div class="v">${profitLine}</div>
-      <div class="k">TOTAL DE INCIDÊNCIAS</div><div class="v">
-        <button class="incidenceToggle" type="button" aria-expanded="false" aria-controls="${accordionId}">
-          <span>Total de incidências (${incidencesPct})</span>
-          <span class="incidenceToggle__icon">▾</span>
+    <div class="resultAccordion__body">
+      ${shopeeToggleHTML}
+
+      <div class="resultGrid resultGrid--support">
+        <div class="k">VOCÊ RECEBE</div><div class="v">${received}</div>
+        <div class="k">LUCRO</div><div class="v">${profitLine}</div>
+        <div class="k">TOTAL DE INCIDÊNCIAS</div><div class="v">
+          <button class="incidenceToggle" type="button" aria-expanded="false" aria-controls="${accordionId}">
+            <span>Total de incidências (${incidencesPct})</span>
+            <span class="incidenceToggle__icon">▾</span>
+          </button>
+        </div>
+        ${extraHTML}
+        ${shopeeInfoHTML}
+      </div>
+
+      <div class="comp">
+        <button class="comp-bar" type="button" role="img" aria-label="${compositionLabel}" data-composition-tip="${compositionTip}">
+          <span class="seg seg-cost" style="width:${composition.pctCost.toFixed(2)}%"></span>
+          <span class="seg seg-fees" style="width:${composition.pctFees.toFixed(2)}%"></span>
+          <span class="seg seg-tax" style="width:${composition.pctTax.toFixed(2)}%"></span>
+          <span class="seg seg-profit" style="width:${composition.pctProfit.toFixed(2)}%"></span>
         </button>
+        <div class="comp-legend">Custo • Taxas • Impostos • Lucro</div>
+        <div class="comp-tip" aria-live="polite" hidden></div>
       </div>
-      ${extraHTML}
-      ${shopeeInfoHTML}
-    </div>
 
-    <div class="comp">
-      <button class="comp-bar" type="button" role="img" aria-label="${compositionLabel}" data-composition-tip="${compositionTip}">
-        <span class="seg seg-cost" style="width:${composition.pctCost.toFixed(2)}%"></span>
-        <span class="seg seg-fees" style="width:${composition.pctFees.toFixed(2)}%"></span>
-        <span class="seg seg-tax" style="width:${composition.pctTax.toFixed(2)}%"></span>
-        <span class="seg seg-profit" style="width:${composition.pctProfit.toFixed(2)}%"></span>
-      </button>
-      <div class="comp-legend">Custo • Taxas • Impostos • Lucro</div>
-      <div class="comp-tip" aria-live="polite" hidden></div>
-    </div>
-
-    <div id="${accordionId}" class="incidencePanel" aria-hidden="true">
-      <div class="resultGrid resultGrid--details">
-        ${itemsHTML}
+      <div id="${accordionId}" class="incidencePanel" aria-hidden="true">
+        <div class="resultGrid resultGrid--details">
+          ${itemsHTML}
+        </div>
       </div>
-    </div>
 
-    ${assumedWeightNoteHTML}
-  </div>
+      ${assumedWeightNoteHTML}
+    </div>
+  </details>
   `;
 }
 
@@ -2484,6 +2493,14 @@ function bind() {
       trackGA4Event("antecipa_toggle", { enabled: !!target.checked });
       recalc({ source: "auto" });
     }
+  });
+
+
+  document.querySelector("#results")?.addEventListener("toggle", (event) => {
+    const details = event.target;
+    if (!(details instanceof HTMLDetailsElement) || !details.classList.contains("resultAccordion")) return;
+    const marketplace = details.querySelector(".cardTitle")?.textContent?.trim() || "unknown";
+    trackGA4Event(details.open ? "open_marketplace_result" : "close_marketplace_result", { section: "results", marketplace });
   });
 
   document.querySelector("#results")?.addEventListener("click", (event) => {

--- a/index.html
+++ b/index.html
@@ -216,7 +216,8 @@
           </section>
 
           <details class="formAccordion" id="commissionAccordion">
-            <summary>Personalizar comissões (opcional)</summary>
+            <summary>Ajustes Avançados por Marketplace</summary>
+            <p class="formAccordion__intro">Ative apenas os ajustes específicos do canal que você deseja simular (comissões, peso e regras por marketplace).</p>
 
             <div class="toggle">
               <label class="check">


### PR DESCRIPTION
### Motivation
- Reduzir sobrecarga cognitiva exibindo um resumo por canal e permitindo inspeção apenas quando necessário; o foco principal é o "Número de Ação" (PREÇO IDEAL / Lucro). 
- Encapsular ajustes avançados por marketplace em uma experiência de divulgação progressiva para simplificar o formulário inicial.

### Description
- Converte os cards de resultado em componentes colapsáveis usando `<details>/<summary>` e exibe o estado resumido com ícone, nome e o valor destacado (`PREÇO IDEAL`) para cada marketplace (`assets/js/main.js`).
- Mantém os detalhes completos (recebimento, lucro, incidências, tabela de incidências e composição em barra empilhada) dentro do corpo expandido do accordion, preservando a composição visual (stacked bar) e comportamento de abertura de incidências (`assets/js/main.js`).
- Ajustes de estilo para reforçar hierarquia tipográfica e responsividade do resumo (aumenta destaque de `heroValue`, reduz peso das informações de apoio e adiciona classes para o novo accordion) (`assets/css/styles.css`).
- Renomeia a seção de inputs opcionais para `Ajustes Avançados por Marketplace` e adiciona microcopy orientando a ativação progressiva desses ajustes (`index.html`).
- Adiciona tracking GA4 para abertura/fechamento dos accordions por marketplace (`assets/js/main.js`).

### Testing
- Executado `node --check assets/js/main.js` para validação sintática do bundle JavaScript; resultado: sucesso.
- Subido servidor local com `python -m http.server 4173` e validado visualmente a nova UI em navegador; resultado: carregamento OK.
- Execução de script Playwright para preencher inputs, disparar `#recalc` e gerar captura de tela (`artifacts/results-accordion.png`) para verificação visual; resultado: sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69983d37ee98833292be31576b0834df)