### PR TITLE
Refactor results panel into collapsible price-focused accordions

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -138,20 +138,23 @@ input:hover,select:hover{border-color:#b8c5d7}
 .advItem--wide{grid-column:1/-1}
 .affGrid{display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px;margin-top:10px}
 
-.resultAccordion{overflow:hidden;padding:0}
+
+.resultAccordion{overflow:hidden;padding:0;border:1px solid var(--stroke);border-radius:14px;background:#fff;box-shadow:var(--shadow-sm)}
 .resultAccordion summary{list-style:none;cursor:pointer;padding:14px 16px}
 .resultAccordion summary::-webkit-details-marker{display:none}
-.resultAccordion__summary{display:grid;gap:10px}
-.resultAccordion__header{margin-bottom:0}
-.resultAccordion__quickStats{display:flex;justify-content:space-between;gap:10px;color:var(--muted);font-size:12px}
-.resultAccordion__quickStats strong{display:block;color:var(--text);font-size:14px;font-weight:700}
-.resultAccordion__heroBox{margin-bottom:0}
-.resultAccordion__body{padding:0 16px 16px;border-top:1px solid var(--stroke)}
-.resultAccordion .heroLabel{font-size:14px;letter-spacing:.1em;font-weight:800}
-.resultAccordion .heroValue{font-size:clamp(36px,4.6vw,50px);font-weight:900}
-.resultAccordion .resultGrid--support .k{font-size:10px;font-weight:600;opacity:.85}
-.resultAccordion .resultGrid--support .v{font-size:13px;font-weight:600}
-.resultAccordion[open] .resultAccordion__summary{padding-bottom:2px}
+.resultAccordion__summaryMain{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.resultAccordion__left{min-width:0;flex:1}
+.resultAccordion__right{text-align:right;min-width:130px}
+.resultAccordion__priceLabel{font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);font-weight:700}
+.resultAccordion__priceValue{font-size:clamp(30px,3.2vw,38px);font-weight:900;line-height:1.05;color:var(--accent)}
+.resultAccordion__chevron{font-size:16px;color:var(--muted);transition:transform .25s ease}
+.resultAccordion[open] .resultAccordion__chevron{transform:rotate(180deg)}
+.resultAccordion .pill--subtle{display:inline-flex;margin-top:4px;font-size:11px;padding:2px 8px;border-radius:999px;border:1px solid var(--stroke);background:#f8fafc;color:#475569}
+.resultAccordion__body{max-height:0;overflow:hidden;padding:0 16px;opacity:0;border-top:0;transition:max-height .35s ease,opacity .25s ease,padding .2s ease,border-color .2s ease}
+.resultAccordion[open] .resultAccordion__body{max-height:900px;opacity:1;padding:0 16px 16px;border-top:1px solid var(--stroke)}
+.resultAccordion:hover{background:#f8fafc}
+.resultAccordion[open]{background:#fff}
+
 .resultList,.marketCompareList{display:flex;flex-direction:column;gap:12px}
 .resultList .card,
 .marketCompareList .card{
@@ -371,8 +374,11 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
   .resultGrid .k{font-size:11px}
   .resultGrid .v{font-size:13px}
   .resultAccordion summary{padding:12px}
-  .resultAccordion__body{padding:0 12px 12px}
-  .resultAccordion__quickStats{display:grid;grid-template-columns:1fr 1fr}
+  .resultAccordion__body{padding:0 12px}
+  .resultAccordion[open] .resultAccordion__body{padding:0 12px 12px}
+  .resultAccordion__summaryMain{align-items:flex-start}
+  .resultAccordion__right{min-width:0}
+  .resultAccordion__priceValue{font-size:clamp(26px,9vw,32px)}
   .stickySummary{left:10px;right:10px;bottom:10px;width:auto;max-height:none;overflow:visible;padding:12px 12px calc(12px + env(safe-area-inset-bottom));border-radius:16px 16px 12px 12px}
   .stickySummary__content{max-height:none;overflow:visible;padding-right:0}
   .stickyOpen{right:10px;bottom:14px}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -871,23 +871,24 @@ function resultCardHTML(
   const cardId = `market-card-${title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
   return `
   <details class="card marketplaceCard resultCard resultAccordion ${options.marketplaceClass || ""}" id="${cardId}">
-    <summary class="resultAccordion__summary">
-      <div class="cardHeader resultAccordion__header">
-        <div class="cardTitleWrap">
-          <span class="cardIcon" aria-hidden="true">${options.marketplaceIcon || "🛒"}</span>
-          <div class="cardTitle">${title}</div>
+    <summary class="resultAccordion__summary" aria-label="${title}: vender por ${price}">
+      <div class="resultAccordion__summaryMain">
+        <div class="resultAccordion__left">
+          <div class="cardTitleWrap">
+            <span class="cardIcon" aria-hidden="true">${options.marketplaceIcon || "🛒"}</span>
+            <div>
+              <div class="cardTitle">${title}</div>
+              <div class="pill pill--subtle">${pill}</div>
+            </div>
+          </div>
         </div>
-        <div class="pill">${pill}</div>
-      </div>
 
-      <div class="heroBox resultAccordion__heroBox">
-        <div class="heroLabel">PREÇO IDEAL</div>
-        <div class="heroValue">${price}</div>
-      </div>
+        <div class="resultAccordion__right">
+          <div class="resultAccordion__priceLabel">VENDER POR:</div>
+          <div class="resultAccordion__priceValue">${price}</div>
+        </div>
 
-      <div class="resultAccordion__quickStats" aria-hidden="true">
-        <div>Você recebe <strong>${received}</strong></div>
-        <div>Incidências <strong>${incidencesPct}</strong></div>
+        <span class="resultAccordion__chevron" aria-hidden="true">▾</span>
       </div>
     </summary>
 
@@ -1872,7 +1873,6 @@ function recalc(options = {}) {
   renderCurrentPriceAnalysis(state);
   renderScaleSimulation(state);
   renderShareActions();
-  renderRankingInsights(computedResults);
   updateLeadCaptureAfterRecalc({
     shouldDisplay: cost > 0,
     computedResults

--- a/index.html
+++ b/index.html
@@ -315,7 +315,7 @@
         <div class="card__inner">
           <h2>Resultados</h2>
           <div id="proModeBadgeSlot"></div>
-          <div id="rankingInsights" class="rankingInsights" aria-live="polite"></div>
+          <!-- Comparativo removido para priorizar leitura rápida do preço ideal por marketplace -->
           <div id="results" class="resultList"></div>
 
           <div id="reportRoot" class="reportRoot" aria-live="polite"></div>


### PR DESCRIPTION
### Motivation
- The results column was visually noisy and hid the primary answer (the ideal selling price) among many technical details, so the UI must prioritize fast scanning of the `Preço Ideal` per marketplace. 
- Users should be able to access detailed breakdowns on demand, not be overwhelmed by them by default.

### Description
- Removed the top comparison/ranking block by removing the `#rankingInsights` output so the results column shows the marketplace list directly (`index.html`).
- Replaced the previous result card header with a compact accordion summary focused on price by updating `resultCardHTML` in `assets/js/main.js` to render a `details`/`summary` structure that shows marketplace icon/name at left and the `VENDER POR:` label + highlighted `Preço Ideal` at right, and added an accessible chevron indicator. 
- Kept the expanded content intact (the `VOCÊ RECEBE` / `LUCRO` block, the stacked composition bar and the `Total de incidências` panel) so details are available only when the accordion is opened. 
- Added CSS rules in `assets/css/styles.css` to style the new accordion: `.resultAccordion__summaryMain`, `.resultAccordion__left`, `.resultAccordion__right`, `.resultAccordion__priceLabel`, `.resultAccordion__priceValue`, chevron rotation and smooth expand/collapse transitions, and responsive adjustments so the price remains visually dominant on mobile. 
- Removed the call to `renderRankingInsights(computedResults)` to avoid re-creating the removed comparison UI in the recalculation flow (`assets/js/main.js`).

### Testing
- Static JS check with `node --check assets/js/main.js` completed successfully and reported no syntax errors. 
- Served the app locally with `python -m http.server 4173` and executed an automated Playwright script that filled `#cost`, `#tax` and `#profitValueBRL`, clicked the calculation button and captured a screenshot (`artifacts/result-accordion.png`), which verified the accordions render closed by default and expand with details. 
- Manual DOM interaction handlers were exercised by the Playwright run and the expand/collapse transitions and incidence toggles worked in the automated run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69985fc30f088332928c690fd86be3c7)