### PR TITLE
Add PDF attachment to pricing summary emails

### DIFF
--- a/api/lead.php
+++ b/api/lead.php
@@ -82,6 +82,12 @@ try {
 
 $summaryBody = buildSummaryEmailBody($nome, $marketplace, $precoMinimo, $precoIdeal);
 $subject = 'Seu resumo de precificação — ' . $marketplace;
-$emailStatus = sendEmailWithFallback($email, $nome, $subject, $summaryBody);
+$pdfContent = buildSummaryPdf($nome, $marketplace, $precoMinimo, $precoIdeal);
+$attachments = [[
+    'content' => $pdfContent,
+    'name' => 'resumo-precificacao.pdf',
+    'mime' => 'application/pdf',
+]];
+$emailStatus = sendEmailWithFallback($email, $nome, $subject, $summaryBody, $attachments);
 
 respond(['success' => true, 'email_sent' => $emailStatus['sent']]);


### PR DESCRIPTION
### Motivation
- Provide recipients with a downloadable PDF version of the pricing summary in addition to the HTML email body.

### Description
- Added `buildSummaryPdf`, `normalizePdfText` and `escapePdfText` in `api/email_sender.php` to generate a lightweight, in-memory PDF with safe text normalization and escaping.
- Extended `sendEmailWithFallback` to accept an `array $attachments` and attach in-memory content using PHPMailer `addStringAttachment` while preserving the existing HTML body and SMTP fallback logic.
- Updated `api/lead.php` to call `buildSummaryPdf` and include a `resumo-precificacao.pdf` attachment when sending the summary email.

### Testing
- Ran `php -l api/email_sender.php` and `php -l api/lead.php` and both reported `No syntax errors detected`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d1305cb588332b42e2cbe22450f3d)