### PR TITLE
Add 4-step pricing wizard UI and marketplace filtering; refactor UX calculation flow

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -665,6 +665,23 @@ body.theme-dark .leadCapture,body.theme-dark .leadCapture__close{background:#1e2
 body.theme-dark .leadCapture__head p{color:#94a3b8}
 @media (max-width:768px){.leadCapture__grid{grid-template-columns:1fr}}
 
+
+.wizardProgress{margin-bottom:16px;padding:10px 12px;border:1px solid var(--stroke);border-radius:12px;background:var(--surface-soft);font-size:13px;font-weight:700;color:var(--text)}
+.wizardStep{display:block}
+.modeCards{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+.modeCard{padding:22px;border:1px solid var(--stroke);border-radius:16px;background:var(--surface);box-shadow:var(--shadow-sm);text-align:left;cursor:pointer;transition:transform .2s ease,border-color .2s ease,background .2s ease}
+.modeCard strong{display:block;margin-bottom:8px;font-size:18px}
+.modeCard p{margin:0;color:var(--muted);line-height:1.45}
+.modeCard:hover{transform:translateY(-2px)}
+.modeCard.is-selected{border-color:var(--accent);background:color-mix(in srgb,var(--accent) 8%, var(--surface) 92%)}
+.wizardActions{margin-top:14px;display:flex;gap:10px;justify-content:space-between}
+.wizardResultsContainer.is-hidden{display:none!important}
+
+@media (max-width:768px){
+  .modeCards{grid-template-columns:1fr}
+  .wizardActions{flex-direction:column}
+}
+
 .marketplaceSelector{display:flex;gap:10px;flex-wrap:wrap;padding-bottom:4px}
 .marketplaceChip{display:inline-flex;align-items:center;gap:8px;min-height:38px;white-space:nowrap;border:1px solid var(--stroke);border-radius:999px;padding:8px 12px;background:var(--surface);font-size:13px;line-height:1.1;cursor:pointer;transition:.2s ease}
 .marketplaceChip:hover{border-color:var(--accent);transform:translateY(-1px)}
@@ -683,4 +700,5 @@ body.theme-dark .leadCapture__head p{color:#94a3b8}
 
 @media (max-width:768px){
   .marketplaceSelector{flex-wrap:nowrap;overflow-x:auto;-webkit-overflow-scrolling:touch;padding-bottom:6px}
+  .marketplaceChip{flex:0 0 auto}
 }

--- a/index.html
+++ b/index.html
@@ -112,26 +112,54 @@
       <div class="grid">
       <div class="card pricingCard">
         <div class="card__inner">
-          <section class="formBlock">
+          <div class="wizardProgress" id="wizardProgress" aria-live="polite">Passo 1 de 4</div>
+
+          <section class="formBlock wizardStep" data-step="1">
             <div class="formBlock__head">
-              <h3>Dados do produto</h3>
-              <p>Use apenas os dados essenciais para iniciar.</p>
+              <h3>Escolha como deseja calcular</h3>
             </div>
 
-            <div class="field" id="calcModeField">
-              <div class="label">Modo de cálculo</div>
+            <div id="calcModeCards" class="modeCards" role="group" aria-label="Escolher modo de cálculo">
+              <button class="modeCard" type="button" data-mode="real">
+                <strong>🟢 Lucro Real</strong>
+                <p>"Descubra quanto você realmente ganha por venda com o preço atual. Inclui comissão, taxas e custos reais do marketplace."</p>
+              </button>
+              <button class="modeCard" type="button" data-mode="ideal">
+                <strong>🔵 Preço Ideal</strong>
+                <p>"Descubra por quanto você deve vender para atingir a margem que deseja. O sistema calcula o preço necessário para cada marketplace."</p>
+              </button>
+            </div>
+
+            <div class="field is-hidden" id="calcModeField">
               <div class="segmented segmented--goal" role="radiogroup" aria-label="Modo de cálculo">
-                <input id="mode_real" type="radio" name="calcMode" value="real" checked />
+                <input id="mode_real" type="radio" name="calcMode" value="real" />
                 <label for="mode_real">Lucro real</label>
                 <input id="mode_ideal" type="radio" name="calcMode" value="ideal" />
                 <label for="mode_ideal">Preço ideal</label>
               </div>
             </div>
+          </section>
+
+          <section class="formBlock wizardStep is-hidden" data-step="2">
+            <div class="formBlock__head">
+              <h3>Selecione marketplaces</h3>
+              <p>Selecione 1 ou mais marketplaces.</p>
+            </div>
 
             <div class="field">
-              <div class="label">Marketplaces</div>
               <div id="marketplaceSelector" class="marketplaceSelector" aria-label="Selecionar marketplaces"></div>
-              <p id="calcModeMicrocopy" class="fieldHint">Descubra o lucro real pelo preço informado em cada marketplace selecionado.</p>
+            </div>
+
+            <div class="actions wizardActions">
+              <button id="wizardBackStep2" class="btn btn--ghost" type="button">Voltar</button>
+              <button id="wizardNextStep2" class="btn btn--primary" type="button" disabled>Continuar</button>
+            </div>
+          </section>
+
+          <section class="formBlock wizardStep is-hidden" data-step="3">
+            <div class="formBlock__head">
+              <h3>Dados do produto</h3>
+              <p>Use apenas os dados essenciais para iniciar.</p>
             </div>
 
             <div class="field">
@@ -230,7 +258,7 @@
           <section class="formBlock" id="mode1PriceSection">
             <div class="formBlock__head">
               <h3>Preço de venda por marketplace</h3>
-              <p>Preencha apenas os marketplaces selecionados.</p>
+              <p id="calcModeMicrocopy">Preço pode variar por marketplace. Preencha o valor correspondente a cada canal.</p>
             </div>
             <div id="mode1PriceInputs" class="modeInputs"></div>
           </section>
@@ -243,7 +271,10 @@
           <div class="formDivider"></div>
 
           <section class="formBlock formBlock--actions">
-            <button id="recalc" class="btn btn--primary btn--wide" type="button">Calcular</button>
+            <div class="actions wizardActions">
+              <button id="wizardBackStep3" class="btn btn--ghost" type="button">Voltar</button>
+              <button id="recalc" class="btn btn--primary" type="button">Calcular</button>
+            </div>
 
             <button id="btnProModeGo" class="btn btn--ghost btn--wide btn--pro-cta" type="button">Calcular no Modo Profissional</button>
             <small class="btnProModeGo__microcopy">Inclui taxas e detalhes que mudam seu lucro real.</small>
@@ -253,6 +284,19 @@
               <select id="savedSimulations" aria-label="Simulações salvas">
                 <option value="">Simulações salvas</option>
               </select>
+            </div>
+          </section>
+
+          </section>
+
+          <section class="formBlock wizardStep is-hidden" data-step="4">
+            <div class="formBlock__head">
+              <h3>Resultado</h3>
+              <p>Confira o resultado por marketplace selecionado.</p>
+            </div>
+            <div class="actions wizardActions">
+              <button id="wizardEditData" class="btn btn--ghost" type="button">Editar dados</button>
+              <button id="wizardNewCalc" class="btn btn--primary" type="button">Novo cálculo</button>
             </div>
           </section>
 
@@ -352,6 +396,7 @@
         </div>
       </div>
 
+      <div class="wizardResultsContainer is-hidden">
       <div class="card stickyResultsCard">
         <div class="card__inner">
           <h2>Resultados</h2>
@@ -387,6 +432,7 @@
 
           <p class="footnote">Sem spam. Só conteúdo útil para vendedor de marketplace.</p>
         </div>
+      </div>
       </div>
       </div>
 


### PR DESCRIPTION
### Motivation
- Introduce a focused multi-step wizard to guide users through choosing calculation mode, selecting marketplaces, entering product data and viewing filtered results.
- Improve UX by decoupling marketplace selection and result rendering so results only show selected channels and the correct microcopy for each mode.
- Prepare plumbing for a professional calculation flow that includes more detailed fees and a filtered results view.

### Description
- Add wizard UI markup to `index.html` including a progress bar (`#wizardProgress`), four wizard steps (`.wizardStep`), mode cards (`.modeCard`), navigation actions and a `wizardResultsContainer` that is hidden until results step.
- Add CSS rules in `assets/css/styles.css` for the wizard, mode cards, responsive behaviors and `.wizardResultsContainer` visibility control.
- Refactor `assets/js/main.js` to implement wizard state and behavior: introduce `wizardStep`, `setWizardStep`, `renderWizardUI`, `validateStep`, `applyWizardResultFilter`, `handleNext`, `handleBack`, and `MARKETPLACE_TITLE_TO_KEY` mapping.
- Change initial marketplace selection to include all `UX_MARKETPLACES` keys by default and preserve `UX_PRICE_VALUES` logic; update `buildMarketplaceSelector` and `renderMode1PriceInputs` integration with wizard events.
- Replace previous direct result rendering calls with `applyWizardResultFilter` that hides non-selected marketplace cards by mapping card titles to marketplace keys.
- Wire up new event listeners to step navigation, mode card clicks, recalc buttons and pro-mode button so actions run `recalc`/`syncGlobalWeightToAdvancedAll` then filter results and advance to the results step; ensure mode radio defaults and microcopy are updated by `toggleUxModeSections`.
- Restore `syncGlobalWeightToAdvancedAll` and keep existing recalculation debounce via `uxRecalc` while ensuring UI re-rendering happens via `renderWizardUI` and `applyWizardResultFilter`.

### Testing
- Ran linting with `npm run lint` and the task completed successfully.
- Performed a build with `npm run build` and the build succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e41da4c78833287f0cfcd83a1e599)