### PR TITLE
hotfix: mover Modo Profissional para o Passo 3 do wizard

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -90,6 +90,8 @@ input:hover,select:hover{border-color:#b8c5d7}
 .formBlock__head p{margin:5px 0 0;color:var(--muted);font-size:13px}
 .formDivider{height:1px;background:var(--stroke);margin:20px 0}
 .formBlock--actions{gap:12px}
+.proModeWizardSlot{margin-top:14px}
+
 
 .segmented{display:flex;gap:8px;padding:6px;border:1px solid #dbe4ef;border-radius:12px;background:linear-gradient(180deg,#f8fafc,#f1f5f9)}
 .segmented--goal{max-width:260px}
@@ -110,6 +112,12 @@ input:hover,select:hover{border-color:#b8c5d7}
 .formAccordion__intro{margin:0 0 10px;color:var(--muted);font-size:12px;line-height:1.4}
 
 .pro-mode{margin-top:18px;padding:20px;border:1px solid #d9d5ff;border-radius:18px;background:linear-gradient(180deg,#ffffff,#f7f5ff);box-shadow:0 10px 30px rgba(76,29,149,.08)}
+.pro-mode.pro-mode--in-wizard{margin-top:0;padding:16px;border:1px solid var(--stroke);border-radius:15px;background:var(--surface-soft,#f8fafc);box-shadow:none}
+.pro-mode.pro-mode--in-wizard .pro-mode__header h3{font-size:18px}
+.pro-mode.pro-mode--in-wizard .pro-mode__subtitle{margin-top:4px;font-size:13px}
+.pro-mode.pro-mode--in-wizard .pro-mode__microcopy{margin-top:8px;font-size:12px}
+.pro-mode.pro-mode--in-wizard .pro-mode__chips{margin-top:10px}
+.pro-mode.pro-mode--in-wizard .pro-mode__content.is-open{max-height:2800px}
 .pro-mode__header h3{margin:0;font-size:22px;letter-spacing:-.01em}
 .pro-mode__subtitle{margin:6px 0 0;font-weight:600;color:#4338ca}
 .pro-mode__microcopy{margin:10px 0 0;color:#475569;line-height:1.45}
@@ -364,7 +372,9 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
   .sectionCard{padding:16px}
   .grid,.row2,.affGrid,.advGrid,.stickySummary__actions,.shareBox__actions,.actions,.currentPriceByMarketplace{grid-template-columns:1fr}
   .pro-mode{padding:16px}
+  .pro-mode.pro-mode--in-wizard{padding:14px}
   .pro-mode__header h3{font-size:19px}
+  .pro-mode.pro-mode--in-wizard .pro-mode__header h3{font-size:17px}
   .pro-mode__chips{gap:6px}
   .pro-chip{font-size:11px}
   .btnProModeGo__microcopy{margin-top:0}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1200,6 +1200,7 @@ function applyProModeState({ persist = true, recalculate = true } = {}) {
 
   const toggleButton = document.querySelector("#proModeToggle");
   const proContent = document.querySelector("#proModeContent");
+  const proModeContainer = document.querySelector("#pro-mode");
   const advToggle = document.querySelector("#advToggle");
 
   if (toggleButton) {
@@ -1212,6 +1213,10 @@ function applyProModeState({ persist = true, recalculate = true } = {}) {
   if (proContent) {
     proContent.classList.toggle("is-open", PRO_MODE_ENABLED);
     proContent.setAttribute("aria-hidden", PRO_MODE_ENABLED ? "false" : "true");
+  }
+
+  if (proModeContainer) {
+    proModeContainer.classList.toggle("is-enabled", PRO_MODE_ENABLED);
   }
 
   if (advToggle && !PRO_MODE_ENABLED) {
@@ -1236,6 +1241,15 @@ function initProMode() {
     PRO_MODE_ENABLED = !PRO_MODE_ENABLED;
     applyProModeState({ persist: true, recalculate: true });
   });
+}
+
+
+function moveProModeIntoWizard() {
+  const slot = document.querySelector("#proModeWizardSlot");
+  const proModeContainer = document.querySelector("#pro-mode");
+  if (!slot || !proModeContainer || slot.contains(proModeContainer)) return;
+  slot.appendChild(proModeContainer);
+  proModeContainer.classList.add("pro-mode--in-wizard");
 }
 
 
@@ -2441,7 +2455,10 @@ function bind() {
   };
 
   $("#btnProModeGo")?.addEventListener("click", () => {
-    scrollToProMode({ openAccordion: true });
+    if (!PRO_MODE_ENABLED) {
+      PRO_MODE_ENABLED = true;
+      applyProModeState({ persist: true, recalculate: false });
+    }
   });
 
   $("#recalc")?.addEventListener("click", () => {
@@ -2953,6 +2970,7 @@ function debounceUxRecalc() {
 function initUxRefactor() {
   buildMarketplaceSelector();
   renderMode1PriceInputs();
+  moveProModeIntoWizard();
 
   const profitValuePct = document.querySelector("#profitValuePct");
   const metaPercent = document.querySelector("#meta_percent");
@@ -3013,6 +3031,11 @@ function initUxRefactor() {
   document.querySelector("#btnProModeGo")?.addEventListener("click", (e) => {
     e.preventDefault();
     e.stopImmediatePropagation();
+
+    if (!PRO_MODE_ENABLED) {
+      PRO_MODE_ENABLED = true;
+      applyProModeState({ persist: true, recalculate: false });
+    }
 
     syncGlobalWeightToAdvancedAll();
     recalc({ source: "manual_pro" });

--- a/index.html
+++ b/index.html
@@ -285,6 +285,8 @@
                 <option value="">Simulações salvas</option>
               </select>
             </div>
+
+            <div id="proModeWizardSlot" class="proModeWizardSlot" aria-live="polite"></div>
           </section>
 
           </section>


### PR DESCRIPTION
### Motivation
- Corrigir a quebra de fluxo onde o `#pro-mode` (Modo Profissional) fica fora do wizard, forçando o usuário a rolar a página para ver ajustes avançados no Passo 3 (especialmente no modo `ideal`).
- Trazer os ajustes imediatamente ao contexto do wizard sem duplicar IDs/HTML e sem alterar a lógica de cálculo existente.

### Description
- Adiciona um slot no Passo 3: `#proModeWizardSlot` logo abaixo das ações do wizard em `index.html` para receber o bloco do Modo Profissional via DOM move.
- Implementa em `assets/js/main.js` a função `moveProModeIntoWizard()` que faz `appendChild` do `#pro-mode` no slot com fallback seguro, e é chamada durante `initUxRefactor()` para teleporte no carregamento; também atualiza `applyProModeState()` para alternar uma classe (`is-enabled`) no container e preserva o comportamento de abrir/fechar o conteúdo (`#proModeContent`).
- Ajusta handlers do CTA `#btnProModeGo` para garantir que, quando clicado, o Pro Mode seja ativado (`PRO_MODE_ENABLED = true`) antes do recálculo, e mantém o conteúdo expandido no contexto do Passo 3 (sem exigir scroll manual para ver ajustes).
- Adiciona estilos em `assets/css/styles.css` para `pro-mode--in-wizard` e `proModeWizardSlot` para integrar visualmente o bloco ao card/wizard (bordas, padding, radius, background e ajustes responsivos mobile), evitando a aparência de seção isolada.

### Testing
- Verificação de sintaxe JavaScript com `node --check assets/js/main.js` — passou com sucesso.
- Validação visual automatizada: iniciei um servidor local (`python -m http.server`) e executei um script headless (Playwright) que selecionou o modo `ideal`, avançou para o Passo 3, validou que `#pro-mode` foi anexado dentro de `#proModeWizardSlot`, clicou em `#proModeToggle` e aguardou `#proModeContent.is-open`; o fluxo completou e um screenshot foi gerado sem erros.
- Testes manuais rápidos no browser confirmaram que no Modo 2 (Preço Ideal) ativar o Modo Profissional expande os ajustes imediatamente dentro do Passo 3, sem duplicação de IDs e mantendo responsividade mobile.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e494a89508332b233630a15d54241)