### PR TITLE
Remove Modo Profissional and integrate advanced adjustments inline in Step 3 wizard

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -90,8 +90,6 @@ input:hover,select:hover{border-color:#b8c5d7}
 .formBlock__head p{margin:5px 0 0;color:var(--muted);font-size:13px}
 .formDivider{height:1px;background:var(--stroke);margin:20px 0}
 .formBlock--actions{gap:12px}
-.proModeWizardSlot{margin-top:14px}
-
 
 .segmented{display:flex;gap:8px;padding:6px;border:1px solid #dbe4ef;border-radius:12px;background:linear-gradient(180deg,#f8fafc,#f1f5f9)}
 .segmented--goal{max-width:260px}
@@ -111,32 +109,12 @@ input:hover,select:hover{border-color:#b8c5d7}
 .formAccordion > :not(summary){padding:0 16px 16px}
 .formAccordion__intro{margin:0 0 10px;color:var(--muted);font-size:12px;line-height:1.4}
 
-.pro-mode{margin-top:18px;padding:20px;border:1px solid #d9d5ff;border-radius:18px;background:linear-gradient(180deg,#ffffff,#f7f5ff);box-shadow:0 10px 30px rgba(76,29,149,.08)}
-.pro-mode.pro-mode--in-wizard{margin-top:0;padding:16px;border:1px solid var(--stroke);border-radius:15px;background:var(--surface-soft,#f8fafc);box-shadow:none}
-.pro-mode.pro-mode--in-wizard .pro-mode__header h3{font-size:18px}
-.pro-mode.pro-mode--in-wizard .pro-mode__subtitle{margin-top:4px;font-size:13px}
-.pro-mode.pro-mode--in-wizard .pro-mode__microcopy{margin-top:8px;font-size:12px}
-.pro-mode.pro-mode--in-wizard .pro-mode__chips{margin-top:10px}
-.pro-mode.pro-mode--in-wizard .pro-mode__content.is-open{max-height:2800px}
-.pro-mode__header h3{margin:0;font-size:22px;letter-spacing:-.01em}
-.pro-mode__subtitle{margin:6px 0 0;font-weight:600;color:#4338ca}
-.pro-mode__microcopy{margin:10px 0 0;color:#475569;line-height:1.45}
-.pro-mode__chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:12px}
-.pro-chip{display:inline-flex;align-items:center;padding:6px 10px;border-radius:999px;background:#eef2ff;border:1px solid #c7d2fe;color:#3730a3;font-size:12px;font-weight:700}
-.pro-mode__toggle{margin-top:14px;width:100%;padding:12px 14px;border:1px solid #c4b5fd;border-radius:12px;background:#fff;font-weight:700;color:#4338ca;cursor:pointer;transition:all .25s ease}
-.pro-mode__toggle:hover{transform:translateY(-1px);box-shadow:0 8px 18px rgba(76,29,149,.14)}
-.pro-mode__toggle.is-on{background:linear-gradient(180deg,#4f46e5,#4338ca);color:#fff;border-color:#4338ca}
-.pro-mode__content{max-height:0;overflow:hidden;opacity:0;transition:max-height .35s ease,opacity .25s ease;margin-top:0}
-.pro-mode__content.is-open{max-height:2200px;opacity:1;margin-top:14px}
-.pro-mode__insight{margin:14px 0 0;font-size:13px;color:#4c1d95;font-weight:600}
-.pro-mode.pro-attention{animation:proPulse 1.4s ease}
-.pro-mode-result-badge{margin:0 0 12px;padding:10px 12px;border-radius:12px;background:#ecfeff;border:1px solid #67e8f9;color:#155e75;font-weight:700}
-
-@keyframes proPulse{
-  0%{box-shadow:0 10px 30px rgba(76,29,149,.08),0 0 0 0 rgba(99,102,241,0);outline:2px solid transparent;outline-offset:2px}
-  30%{box-shadow:0 14px 34px rgba(76,29,149,.16),0 0 0 6px rgba(99,102,241,.18);outline:2px solid rgba(99,102,241,.42)}
-  100%{box-shadow:0 10px 30px rgba(76,29,149,.08),0 0 0 0 rgba(99,102,241,0);outline:2px solid transparent;outline-offset:2px}
-}
+.optionalAdjustments{border-color:#dbe4ef;background:linear-gradient(180deg,#ffffff,#f8fafc);box-shadow:none}
+.optionalAdjustments summary{font-size:15px}
+.optionalGroup{margin-top:12px;padding:12px;border:1px solid #e2e8f0;border-radius:12px;background:#fff}
+.optionalGroup h4{margin:0 0 8px;font-size:13px;color:#334155;letter-spacing:.02em;text-transform:uppercase}
+.optionalInlineBox{overflow:hidden;max-height:0;opacity:0;transform:translateY(-4px);transition:max-height .28s ease,opacity .2s ease,transform .2s ease;margin-top:0}
+.optionalInlineBox.is-open{max-height:1200px;opacity:1;transform:translateY(0);margin-top:10px}
 
 .cardMini{margin-top:14px;border-radius:14px;border:1px solid var(--stroke);background:#fff;padding:14px}
 .cardMini__header{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px}
@@ -319,9 +297,6 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
 .actions--stacked{margin-top:0;display:grid;grid-template-columns:1fr;gap:10px}
 
 .formActionsSecondary .btn--ghost{border-color:#cbd5e1;background:#f8fafc;font-weight:600}
-.btn--pro-cta{border-color:#c7d2fe;background:linear-gradient(180deg,#f8faff,#eef2ff);color:#3730a3;font-weight:700}
-.btn--pro-cta:hover{border-color:#a5b4fc;box-shadow:0 8px 18px rgba(67,56,202,.14);transform:translateY(-1px)}
-.btnProModeGo__microcopy{display:block;margin-top:-4px;color:#64748b;font-size:12px;line-height:1.35}
 
 .marketplaceCard .cardHeader{padding:14px 16px;margin:-1px -1px 10px;border-radius:16px 16px 0 0;border-bottom:1px solid var(--stroke)}
 .marketplaceCard.marketplace-shopee .cardHeader{background:rgba(238,77,45,.08)}
@@ -371,13 +346,6 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
   .segmentMenu__btn{flex:0 0 auto;scroll-snap-align:start;white-space:nowrap}
   .sectionCard{padding:16px}
   .grid,.row2,.affGrid,.advGrid,.stickySummary__actions,.shareBox__actions,.actions,.currentPriceByMarketplace{grid-template-columns:1fr}
-  .pro-mode{padding:16px}
-  .pro-mode.pro-mode--in-wizard{padding:14px}
-  .pro-mode__header h3{font-size:19px}
-  .pro-mode.pro-mode--in-wizard .pro-mode__header h3{font-size:17px}
-  .pro-mode__chips{gap:6px}
-  .pro-chip{font-size:11px}
-  .btnProModeGo__microcopy{margin-top:0}
   .card__inner{padding:16px}
   .cardHeader{flex-wrap:wrap}
   .cardHeader .pill{margin-top:2px}
@@ -398,6 +366,8 @@ body.theme-dark .btn--ghost,body.theme-dark input,body.theme-dark select,body.th
   .shareBox .btn,.stickySummary .btn,.actions .btn,#pdfButtonContainer .btn{width:100%}
   .formAccordion summary{padding:12px 12px}
   .formAccordion > :not(summary){padding:0 12px 12px}
+  .optionalGroup{padding:10px}
+  .optionalInlineBox.is-open{max-height:1600px}
   .segmented--goal{max-width:none;width:100%}
   .resultList .card,.marketCompareList .card{overflow:visible}
   .topbar__controls .btn{display:none}
@@ -657,7 +627,6 @@ body.theme-dark .resultCard .pill{
 
 @media (prefers-reduced-motion: reduce){
   html,body{scroll-behavior:auto}
-  .pro-mode.pro-attention{animation:none}
 }
 
 .leadCapture{margin-top:14px;border:1px solid var(--stroke);border-radius:14px;background:#fff;padding:14px;box-shadow:var(--shadow-sm)}

--- a/index.html
+++ b/index.html
@@ -211,9 +211,9 @@
             </div>
           </section>
 
-          <div class="formDivider"></div>
+          <div class="formDivider wizardStep is-hidden" data-step="3"></div>
 
-          <section class="formBlock" id="profitGoalSection">
+          <section class="formBlock wizardStep is-hidden" data-step="3" id="profitGoalSection">
             <div class="formBlock__head">
               <h3 id="profitGoalHeading">Meta de lucro</h3>
               <p>Defina sua meta em valor fixo ou em percentual.</p>
@@ -255,7 +255,226 @@
             <input id="profitValue" class="is-hidden" type="number" step="0.01" min="0" value="10" tabindex="-1" aria-hidden="true" />
           </section>
 
-          <section class="formBlock" id="mode1PriceSection">
+<details class="formAccordion optionalAdjustments wizardStep is-hidden" data-step="3" id="commissionAccordion">
+            <summary>Ajustes adicionais (opcional)</summary>
+            <p class="formAccordion__intro">Marque apenas o que se aplica ao seu cenário.</p>
+
+            <div class="optionalGroup">
+              <h4>Marketplaces</h4>
+
+              <div class="toggle">
+                <label class="check">
+                  <input id="mlCommissionToggle" type="checkbox" />
+                  <span>Definir comissão Mercado Livre</span>
+                </label>
+              </div>
+              <div id="mlCommissionBox" class="cardMini optionalInlineBox is-hidden">
+                <div class="row2">
+                  <div class="field">
+                    <div class="label label-row">
+                      <span>ML Clássico (%)</span>
+                      <button class="info" type="button" aria-label="Info: Mercado Livre Clássico (%)" data-tooltip="Por padrão usamos 14%. Você pode editar conforme sua categoria/anúncio.">i</button>
+                    </div>
+                    <input id="mlClassicPct" type="number" step="0.01" min="0" value="14" />
+                  </div>
+
+                  <div class="field">
+                    <div class="label label-row">
+                      <span>ML Premium (%)</span>
+                      <button class="info" type="button" aria-label="Info: Mercado Livre Premium (%)" data-tooltip="Por padrão usamos 19%. Você pode editar conforme sua categoria/anúncio.">i</button>
+                    </div>
+                    <input id="mlPremiumPct" type="number" step="0.01" min="0" value="19" />
+                  </div>
+                </div>
+              </div>
+
+              <div class="toggle">
+                <label class="check">
+                  <input id="sheinCommissionToggle" type="checkbox" />
+                  <span>Definir comissão SHEIN</span>
+                </label>
+              </div>
+              <div id="sheinCommissionBox" class="cardMini optionalInlineBox is-hidden">
+                <div class="field">
+                  <div class="label label-row">
+                    <span>Categoria SHEIN</span>
+                    <button class="info" type="button" aria-label="Info: Categoria SHEIN" data-tooltip="A comissão da SHEIN varia por categoria: Vestuário feminino 20% e demais categorias 18%.">i</button>
+                  </div>
+                  <select id="sheinCategory">
+                    <option value="other" selected>Demais categorias (18%)</option>
+                    <option value="female">Vestuário feminino (20%)</option>
+                  </select>
+                </div>
+              </div>
+
+              <div class="toggle">
+                <label class="check">
+                  <input id="amazonDbaToggle" type="checkbox" checked />
+                  <span>Incluir Amazon (DBA) no cálculo</span>
+                </label>
+                <small>Ative para aplicar comissão e tarifa logística DBA por unidade.</small>
+              </div>
+              <div id="amazonDbaBox" class="cardMini optionalInlineBox is-hidden">
+                <div class="cardMini__header">
+                  <strong>Amazon (DBA)</strong>
+                  <span class="pill">Opcional</span>
+                </div>
+
+                <div class="field">
+                  <div class="label label-row">
+                    <span>Comissão Amazon (%)</span>
+                    <button class="info" type="button" aria-label="Info: Comissão Amazon (%)" data-tooltip="A comissão padrão da Amazon foi definida em 15%, mas você pode ajustar conforme sua categoria.">i</button>
+                  </div>
+                  <input id="amazonPct" type="number" step="0.01" min="0" value="15" />
+                </div>
+
+                <small>DBA usa o maior entre peso real e cúbico. Aqui usamos o peso informado.</small>
+                <small>Se o peso não estiver ativo, calculamos com padrão de 0,5 kg.</small>
+
+                <div id="amazonOriginWrap" class="field is-hidden">
+                  <div class="label label-row">
+                    <span>Origem do envio (DBA)</span>
+                    <button class="info" type="button" aria-label="Info: Origem do envio (DBA)" data-tooltip="A origem é exigida no bloco de produtos acima de R$ 200 na tabela DBA da Amazon.">i</button>
+                  </div>
+                  <select id="amazonOriginGroup">
+                    <option value="sp_capital">SP Capital</option>
+                    <option value="sul_sudeste_capitais">Outras capitais do Sul e Sudeste</option>
+                    <option value="sul_sudeste_interior">Interior do Sul e Sudeste</option>
+                    <option value="co_ne_no">Centro-Oeste, Norte e Nordeste</option>
+                  </select>
+                </div>
+              </div>
+
+              <div class="toggle">
+                <label class="check">
+                  <input id="affToggle" type="checkbox" />
+                  <span>Afiliados por canal (%)</span>
+                </label>
+              </div>
+              <div id="affBox" class="cardMini optionalInlineBox affGrid is-hidden">
+                <div class="field">
+                  <div class="label label-row">
+                    <span>Afiliados Shopee (%)</span>
+                    <button class="info" type="button" aria-label="Info: Afiliados Shopee (%)" data-tooltip="Percentual pago ao afiliado dentro da Shopee. Incide só no cálculo da Shopee.">i</button>
+                  </div>
+                  <input id="affShopee" type="number" step="0.01" min="0" value="0" />
+                </div>
+
+                <div class="field">
+                  <div class="label label-row">
+                    <span>Afiliados Mercado Livre (%)</span>
+                    <button class="info" type="button" aria-label="Info: Afiliados Mercado Livre (%)" data-tooltip="Percentual de custo de afiliados/CPA do Mercado Livre. Incide só no cálculo do ML (Clássico e Premium).">i</button>
+                  </div>
+                  <input id="affML" type="number" step="0.01" min="0" value="0" />
+                </div>
+
+                <div class="field">
+                  <div class="label label-row">
+                    <span>Afiliados TikTok (%)</span>
+                    <button class="info" type="button" aria-label="Info: Afiliados TikTok (%)" data-tooltip="Percentual pago ao afiliado dentro do TikTok Shop. Incide só no cálculo do TikTok.">i</button>
+                  </div>
+                  <input id="affTikTok" type="number" step="0.01" min="0" value="0" />
+                </div>
+              </div>
+            </div>
+
+            <div class="optionalGroup">
+              <h4>Custos extras</h4>
+
+              <div class="toggle">
+                <label class="check">
+                  <input id="advToggle" type="checkbox" />
+                  <span>Aplicar custos percentuais/fixos extras</span>
+                </label>
+              </div>
+
+              <div id="advBox" class="optionalInlineBox is-hidden">
+                <div class="advGrid">
+                  <div class="advItem">
+                    <div class="label label-row">
+                      <label class="check">
+                        <input id="adsToggle" type="checkbox" />
+                        <span>Custo de Ads</span>
+                      </label>
+                      <button class="info" type="button" aria-label="Info: Custo de Ads" data-tooltip="Informe quanto do seu faturamento é gasto em ads (%). Ex: se a cada R$ 100 vendidos você gasta R$ 8 em anúncios, preencha 8%.">i</button>
+                    </div>
+                    <div class="row2">
+                      <select id="adsType"><option value="pct">Em %</option><option value="brl">Em R$</option></select>
+                      <input id="adsValue" type="number" step="0.01" min="0" value="0" />
+                    </div>
+                  </div>
+
+                  <div class="advItem">
+                    <div class="label label-row">
+                      <label class="check">
+                        <input id="returnToggle" type="checkbox" />
+                        <span>Taxa de devolução</span>
+                      </label>
+                      <button class="info" type="button" aria-label="Info: Custo de devolução" data-tooltip="Estimativa de devolução/troca. Pode ser percentual do faturamento ou valor fixo por venda.">i</button>
+                    </div>
+                    <div class="row2">
+                      <select id="returnType"><option value="pct">Em %</option><option value="brl">Em R$</option></select>
+                      <input id="returnValue" type="number" step="0.01" min="0" value="0" />
+                    </div>
+                  </div>
+
+                  <div class="advItem">
+                    <label class="check"><input id="costFixedToggle" type="checkbox" /><span>Custo fixo por pedido</span></label>
+                    <div class="row2">
+                      <select id="costFixedType"><option value="brl" selected>Em R$</option><option value="pct">Em %</option></select>
+                      <input id="costFixedValue" type="number" step="0.01" min="0" value="0" />
+                    </div>
+                  </div>
+
+                  <div class="advItem"><label class="check"><input id="difalToggle" type="checkbox" /><span>DIFAL (%)</span></label><input id="difalValue" type="number" step="0.01" min="0" value="0" /></div>
+                  <div class="advItem"><label class="check"><input id="pisToggle" type="checkbox" /><span>PIS (%)</span></label><input id="pisValue" type="number" step="0.01" min="0" value="0" /></div>
+                  <div class="advItem"><label class="check"><input id="cofinsToggle" type="checkbox" /><span>COFINS (%)</span></label><input id="cofinsValue" type="number" step="0.01" min="0" value="0" /></div>
+
+                  <div class="advItem">
+                    <label class="check"><input id="otherToggle" type="checkbox" /><span>Outro custo</span></label>
+                    <div class="row2">
+                      <select id="otherType"><option value="pct">Em %</option><option value="brl">Em R$</option></select>
+                      <input id="otherValue" type="number" step="0.01" min="0" value="0" />
+                    </div>
+                  </div>
+                </div>
+
+                <div class="hint">Regras: itens em R$ entram como custo fixo. Itens em % entram como incidência.</div>
+              </div>
+            </div>
+
+            <div class="optionalGroup">
+              <h4>Frete/Peso</h4>
+
+              <div class="toggle">
+                <label class="check">
+                  <input id="mlWeightToggle" type="checkbox" />
+                  <span>Informar peso (Mercado Livre + SHEIN)</span>
+                </label>
+                <small>A SHEIN também aplica intermediação de frete por faixa de peso.</small>
+              </div>
+
+              <div id="mlWeightBox" class="row2 optionalInlineBox is-hidden">
+                <div class="field">
+                  <div class="label label-row">
+                    <span>Peso</span>
+                    <button class="info" type="button" aria-label="Info: Peso" data-tooltip="Peso do produto para cálculo do custo fixo de envio do Mercado Livre. Se não informar, o sistema assume 500g por padrão.">i</button>
+                  </div>
+                  <input id="mlWeightValue" type="number" step="0.001" min="0" value="0.5" />
+                </div>
+
+                <div class="field">
+                  <div class="label label-row">
+                    <span>Unidade</span>
+                    <button class="info" type="button" aria-label="Info: Unidade" data-tooltip="Escolha gramas (g) ou quilogramas (kg). Ex: 500g = 0,5kg.">i</button>
+                  </div>
+                  <select id="mlWeightUnit"><option value="kg">kg</option><option value="g">g</option></select>
+                </div>
+              </div>
+            </div>
+          </details>
+
+          <section class="formBlock wizardStep is-hidden" data-step="3" id="mode1PriceSection">
             <div class="formBlock__head">
               <h3>Preço de venda por marketplace</h3>
               <p id="calcModeMicrocopy">Preço pode variar por marketplace. Preencha o valor correspondente a cada canal.</p>
@@ -263,21 +482,18 @@
             <div id="mode1PriceInputs" class="modeInputs"></div>
           </section>
 
-          <details class="formInfoDetails">
+          <details class="formInfoDetails wizardStep is-hidden" data-step="3">
             <summary>Como calculamos?</summary>
             <p>Regra: custos fixos e lucro em R$ somam no custo. Depois, somamos incidências em % (comissão + imposto [+ lucro% se escolhido] + custos%) e calculamos: <strong>Preço = custo ajustado ÷ (1 − incidências)</strong>.</p>
           </details>
 
-          <div class="formDivider"></div>
+          <div class="formDivider wizardStep is-hidden" data-step="3"></div>
 
-          <section class="formBlock formBlock--actions">
+          <section class="formBlock formBlock--actions wizardStep is-hidden" data-step="3">
             <div class="actions wizardActions">
               <button id="wizardBackStep3" class="btn btn--ghost" type="button">Voltar</button>
               <button id="recalc" class="btn btn--primary" type="button">Calcular</button>
             </div>
-
-            <button id="btnProModeGo" class="btn btn--ghost btn--wide btn--pro-cta" type="button">Calcular no Modo Profissional</button>
-            <small class="btnProModeGo__microcopy">Inclui taxas e detalhes que mudam seu lucro real.</small>
 
             <div class="actions actions--stacked formActionsSecondary">
               <button id="saveSimulation" class="btn btn--ghost btn--wide" type="button">Salvar simulação</button>
@@ -285,9 +501,6 @@
                 <option value="">Simulações salvas</option>
               </select>
             </div>
-
-            <div id="proModeWizardSlot" class="proModeWizardSlot" aria-live="polite"></div>
-          </section>
 
           </section>
 
@@ -302,99 +515,9 @@
             </div>
           </section>
 
-          <details class="formAccordion" id="commissionAccordion">
-            <summary>Ajustes Avançados por Marketplace</summary>
-            <p class="formAccordion__intro">Ative apenas os ajustes específicos do canal que você deseja simular (comissões, peso e regras por marketplace).</p>
 
-            <div class="toggle">
-              <label class="check">
-                <input id="mlCommissionToggle" type="checkbox" />
-                <span>Definir comissão Mercado Livre</span>
-              </label>
-            </div>
 
-            <div id="mlCommissionBox" class="cardMini is-hidden">
-              <div class="row2">
-                <div class="field">
-                  <div class="label label-row">
-                    <span>ML Clássico (%)</span>
-                    <button class="info" type="button" aria-label="Info: Mercado Livre Clássico (%)" data-tooltip="Por padrão usamos 14%. Você pode editar conforme sua categoria/anúncio.">i</button>
-                  </div>
-                  <input id="mlClassicPct" type="number" step="0.01" min="0" value="14" />
-                </div>
 
-                <div class="field">
-                  <div class="label label-row">
-                    <span>ML Premium (%)</span>
-                    <button class="info" type="button" aria-label="Info: Mercado Livre Premium (%)" data-tooltip="Por padrão usamos 19%. Você pode editar conforme sua categoria/anúncio.">i</button>
-                  </div>
-                  <input id="mlPremiumPct" type="number" step="0.01" min="0" value="19" />
-                </div>
-              </div>
-            </div>
-
-            <div class="toggle">
-              <label class="check">
-                <input id="sheinCommissionToggle" type="checkbox" />
-                <span>Definir comissão SHEIN</span>
-              </label>
-            </div>
-
-            <div id="sheinCommissionBox" class="cardMini is-hidden">
-              <div class="field">
-                <div class="label label-row">
-                  <span>Categoria SHEIN</span>
-                  <button class="info" type="button" aria-label="Info: Categoria SHEIN" data-tooltip="A comissão da SHEIN varia por categoria: Vestuário feminino 20% e demais categorias 18%.">i</button>
-                </div>
-                <select id="sheinCategory">
-                  <option value="other" selected>Demais categorias (18%)</option>
-                  <option value="female">Vestuário feminino (20%)</option>
-                </select>
-              </div>
-            </div>
-
-            <div class="toggle">
-              <label class="check">
-                <input id="amazonDbaToggle" type="checkbox" checked />
-                <span>Incluir Amazon (DBA) no cálculo</span>
-              </label>
-              <small>Ative para aplicar comissão e tarifa logística DBA por unidade.</small>
-            </div>
-
-            <div id="amazonDbaBox" class="cardMini is-hidden">
-            <div class="cardMini__header">
-              <strong>Amazon (DBA)</strong>
-              <span class="pill">Opcional</span>
-            </div>
-
-            <div class="field">
-              <div class="label label-row">
-                <span>Comissão Amazon (%)</span>
-                <button class="info" type="button" aria-label="Info: Comissão Amazon (%)" data-tooltip="A comissão padrão da Amazon foi definida em 15%, mas você pode ajustar conforme sua categoria.">i</button>
-              </div>
-              <input id="amazonPct" type="number" step="0.01" min="0" value="15" />
-            </div>
-
-            <small>DBA usa o maior entre peso real e cúbico. Aqui usamos o peso informado.</small>
-            <small>Se o peso não estiver ativo, calculamos com padrão de 0,5 kg.</small>
-
-            <div id="amazonOriginWrap" class="field is-hidden">
-              <div class="label label-row">
-                <span>Origem do envio (DBA)</span>
-                <button class="info" type="button" aria-label="Info: Origem do envio (DBA)" data-tooltip="A origem é exigida no bloco de produtos acima de R$ 200 na tabela DBA da Amazon.">i</button>
-              </div>
-              <select id="amazonOriginGroup">
-                <option value="sp_capital">SP Capital</option>
-                <option value="sul_sudeste_capitais">Outras capitais do Sul e Sudeste</option>
-                <option value="sul_sudeste_interior">Interior do Sul e Sudeste</option>
-                <option value="co_ne_no">Centro-Oeste, Norte e Nordeste</option>
-              </select>
-            </div>
-          </div>
-
-          </details>
-
-          
         </div>
       </div>
 
@@ -402,7 +525,6 @@
       <div class="card stickyResultsCard">
         <div class="card__inner">
           <h2>Resultados</h2>
-          <div id="proModeBadgeSlot"></div>
           <!-- Comparativo removido para priorizar leitura rápida do preço ideal por marketplace -->
           <div id="results" class="resultList"></div>
 
@@ -438,216 +560,7 @@
       </div>
       </div>
 
-      <section id="pro-mode" class="pro-mode" aria-labelledby="proModeTitle">
-        <div class="pro-mode__header">
-          <h3 id="proModeTitle">💎 Modo Profissional (recomendado)</h3>
-          <p class="pro-mode__subtitle">Inclua taxas e detalhes que mudam seu lucro de verdade.</p>
-          <p class="pro-mode__microcopy">Evite precificar no “olhômetro”.<br />Ative para considerar impostos, taxas extras e regras específicas do marketplace.</p>
-
-          <div class="pro-mode__chips" aria-label="Itens cobertos no modo profissional">
-            <span class="pro-chip">Impostos</span>
-            <span class="pro-chip">Taxas do marketplace</span>
-            <span class="pro-chip">Frete / Peso</span>
-            <span class="pro-chip">Custos extras</span>
-            <span class="pro-chip">Antecipação / recebimento</span>
-          </div>
-
-          <button
-            id="proModeToggle"
-            class="pro-mode__toggle"
-            type="button"
-            aria-pressed="false"
-            aria-expanded="false"
-            aria-controls="proModeContent"
-          >
-            Ativar Modo Profissional
-          </button>
-        </div>
-
-        <div id="proModeContent" class="pro-mode__content" aria-hidden="true">
-          <div class="toggle">
-            <label class="check">
-              <input id="mlWeightToggle" type="checkbox" />
-              <span>Informar peso (Mercado Livre + SHEIN)</span>
-            </label>
-            <small>A SHEIN também aplica intermediação de frete por faixa de peso.</small>
-          </div>
-
-          <div id="mlWeightBox" class="row2 is-hidden">
-            <div class="field">
-              <div class="label label-row">
-                <span>Peso</span>
-                <button class="info" type="button" aria-label="Info: Peso" data-tooltip="Peso do produto para cálculo do custo fixo de envio do Mercado Livre. Se não informar, o sistema assume 500g por padrão.">i</button>
-              </div>
-              <input id="mlWeightValue" type="number" step="0.001" min="0" value="0.5" />
-            </div>
-
-            <div class="field">
-              <div class="label label-row">
-                <span>Unidade</span>
-                <button class="info" type="button" aria-label="Info: Unidade" data-tooltip="Escolha gramas (g) ou quilogramas (kg). Ex: 500g = 0,5kg.">i</button>
-              </div>
-              <select id="mlWeightUnit">
-                <option value="kg">kg</option>
-                <option value="g">g</option>
-              </select>
-            </div>
-          </div>
-
-          <div class="toggle">
-            <label class="check">
-              <input id="advToggle" type="checkbox" />
-              <span>Aplicar variáveis avançadas</span>
-            </label>
-            <small>Ads, devolução, custo fixo, DIFAL, PIS, COFINS, outro e afiliados.</small>
-          </div>
-
-          <div id="advBox" class="is-hidden">
-            <div class="advGrid">
-              <div class="advItem">
-                <div class="label label-row">
-                  <label class="check">
-                    <input id="adsToggle" type="checkbox" />
-                    <span>Custo de Ads</span>
-                  </label>
-                  <button
-                    class="info"
-                    type="button"
-                    aria-label="Info: Custo de Ads"
-                    data-tooltip="Informe quanto do seu faturamento é gasto em ads (%). Ex: se a cada R$ 100 vendidos você gasta R$ 8 em anúncios, preencha 8%."
-                  >i</button>
-                </div>
-
-                <div class="row2">
-                  <select id="adsType">
-                    <option value="pct">Em %</option>
-                    <option value="brl">Em R$</option>
-                  </select>
-                  <input id="adsValue" type="number" step="0.01" min="0" value="0" />
-                </div>
-              </div>
-
-              <div class="advItem">
-                <div class="label label-row">
-                  <label class="check">
-                    <input id="returnToggle" type="checkbox" />
-                    <span>Custo de devolução</span>
-                  </label>
-                  <button
-                    class="info"
-                    type="button"
-                    aria-label="Info: Custo de devolução"
-                    data-tooltip="Estimativa de devolução/troca. Pode ser percentual do faturamento ou valor fixo por venda."
-                  >i</button>
-                </div>
-
-                <div class="row2">
-                  <select id="returnType">
-                    <option value="pct">Em %</option>
-                    <option value="brl">Em R$</option>
-                  </select>
-                  <input id="returnValue" type="number" step="0.01" min="0" value="0" />
-                </div>
-              </div>
-
-              <div class="advItem">
-                <label class="check">
-                  <input id="costFixedToggle" type="checkbox" />
-                  <span>Custo fixo</span>
-                </label>
-                <div class="row2">
-                  <select id="costFixedType">
-                    <option value="brl" selected>Em R$</option>
-                    <option value="pct">Em %</option>
-                  </select>
-                  <input id="costFixedValue" type="number" step="0.01" min="0" value="0" />
-                </div>
-              </div>
-
-              <div class="advItem">
-                <label class="check">
-                  <input id="difalToggle" type="checkbox" />
-                  <span>DIFAL (%)</span>
-                </label>
-                <input id="difalValue" type="number" step="0.01" min="0" value="0" />
-              </div>
-
-              <div class="advItem">
-                <label class="check">
-                  <input id="pisToggle" type="checkbox" />
-                  <span>PIS (%)</span>
-                </label>
-                <input id="pisValue" type="number" step="0.01" min="0" value="0" />
-              </div>
-
-              <div class="advItem">
-                <label class="check">
-                  <input id="cofinsToggle" type="checkbox" />
-                  <span>COFINS (%)</span>
-                </label>
-                <input id="cofinsValue" type="number" step="0.01" min="0" value="0" />
-              </div>
-
-              <div class="advItem">
-                <label class="check">
-                  <input id="otherToggle" type="checkbox" />
-                  <span>Outro</span>
-                </label>
-                <div class="row2">
-                  <select id="otherType">
-                    <option value="pct">Em %</option>
-                    <option value="brl">Em R$</option>
-                  </select>
-                  <input id="otherValue" type="number" step="0.01" min="0" value="0" />
-                </div>
-              </div>
-
-              <div class="advItem advItem--wide">
-                <label class="check">
-                  <input id="affToggle" type="checkbox" />
-                  <span>Afiliados</span>
-                </label>
-                <small>Incide somente na plataforma correspondente (Shopee, Mercado Livre e TikTok).</small>
-
-                <div id="affBox" class="affGrid is-hidden">
-                  <div class="field">
-                    <div class="label label-row">
-                      <span>Afiliados Shopee (%)</span>
-                      <button class="info" type="button" aria-label="Info: Afiliados Shopee (%)" data-tooltip="Percentual pago ao afiliado dentro da Shopee. Incide só no cálculo da Shopee.">i</button>
-                    </div>
-                    <input id="affShopee" type="number" step="0.01" min="0" value="0" />
-                  </div>
-
-                  <div class="field">
-                    <div class="label label-row">
-                      <span>Afiliados Mercado Livre (%)</span>
-                      <button class="info" type="button" aria-label="Info: Afiliados Mercado Livre (%)" data-tooltip="Percentual de custo de afiliados/CPA do Mercado Livre. Incide só no cálculo do ML (Clássico e Premium).">i</button>
-                    </div>
-                    <input id="affML" type="number" step="0.01" min="0" value="0" />
-                  </div>
-
-                  <div class="field">
-                    <div class="label label-row">
-                      <span>Afiliados TikTok (%)</span>
-                      <button class="info" type="button" aria-label="Info: Afiliados TikTok (%)" data-tooltip="Percentual pago ao afiliado dentro do TikTok Shop. Incide só no cálculo do TikTok.">i</button>
-                    </div>
-                    <input id="affTikTok" type="number" step="0.01" min="0" value="0" />
-                  </div>
-                </div>
-
-              </div>
-            </div>
-
-            <div class="hint">
-              Regras: itens em R$ entram como custo fixo (somam no custo). Itens em % entram como incidência (somam nas %).
-            </div>
-          </div>
-        </div>
-        <p id="proModeInsight" class="pro-mode__insight">Dica: ajustes profissionais podem mudar seu lucro final.</p>
-      </section>
-    </section>
-
-    <section class="yt-section" id="videos">
+      <section class="yt-section" id="videos">
       <div class="yt-header">
         <div class="yt-header-left">
           <h2>Últimos vídeos sobre Marketplace</h2>


### PR DESCRIPTION
### Motivation
- Simplificar o fluxo e eliminar o conceito separado de “Modo Profissional” mantendo todas as variáveis avançadas acessíveis e opcionais dentro do passo 3 do wizard para melhorar descoberta e reduzir fricção.
- Manter todos os cálculos existentes e o comportamento responsivo enquanto reorganiza a UI para mostrar ajustes como opcionais e inline, sem espaços vazios ou duplicação de conteúdo.

### Description
- HTML: remove a seção e CTA do `Modo Profissional` e insere o accordion renomeado para `Ajustes adicionais (opcional)` dentro do passo 3 (`data-step="3"`), com microcopy `Marque apenas o que se aplica ao seu cenário.` e grupos `Marketplaces`, `Custos extras` e `Frete/Peso`, fechados por padrão. (file: `index.html`).
- JS: elimina dependência em `proMode` e lógica relacionada, faz `getCalculationConfig()` usar `getAdvancedVars()` diretamente, torna o toggle de peso/afiliados/advances independentes, adiciona `setInlineBoxVisibility()` para expansão inline, e garante que o botão `#recalc` execute `syncGlobalWeightToAdvancedAll()`, `recalc({ source: "manual" })`, `applyWizardResultFilter()` e `setWizardStep(4)`. (file: `assets/js/main.js`).
- UX: reorganiza toggles como checkboxes que revelam imediatamente o bloco inline correspondente (sem mover conteúdo fora de contexto) usando transições suaves; sincroniza peso global com caixas avançadas ao recalcular.
- CSS: adiciona estilos discretos e responsivos para o novo bloco (`.optionalAdjustments`, `.optionalGroup`, `.optionalInlineBox`), remove estilos/visuais específicos do modo profissional e mantém consistência com os cards existentes. (file: `assets/css/styles.css`).
- Arquivos principais alterados: `index.html`, `assets/js/main.js`, `assets/css/styles.css`.

### Testing
- Executou `node --check assets/js/main.js` e não retornou erros, confirmando que o bundle JS é sintaticamente válido.
- Executou `git diff --check` e verificações de lint básicas sem erros de trilha; e pesquisou por ocorrências de “Modo Profissional” / `btnProModeGo` / `manual_pro` com `rg` sem encontrar menções visíveis, validando remoção do modo separado.
- Smoke tests automatizados via Playwright abrindo a aplicação local, navegando pelo wizard (fluxos `Lucro Real` e `Preço Ideal`), abrindo o accordion de ajustes, marcando `mlCommissionToggle`, `advToggle` e `mlWeightToggle` e disparando `#recalc`, com resultados da sessão registrada como `real=6;ideal=6;pro=0`, ou seja, resultados visíveis por marketplace OK e nenhuma menção a “Modo Profissional”.
- Servidor local usado para testes manual/automáticos com `python3 -m http.server` e screenshots capturadas para validação visual do passo 3 e dos boxes inline (artefato gerado durante validação).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ed71b5f6c8332917d36d514d7ea93)