### PR TITLE
hotfix: remove duplicated margin section from step 2

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2744,8 +2744,9 @@ function renderMode1PriceInputs() {
 
 function toggleUxModeSections() {
   const mode = getCalcMode();
-  document.querySelector("#mode1PriceSection")?.classList.toggle("is-hidden", mode !== "real");
-  document.querySelector("#profitGoalSection")?.classList.toggle("is-hidden", mode === "real");
+  const isStep3 = wizardStep === 3;
+  document.querySelector("#mode1PriceSection")?.classList.toggle("is-hidden", !(mode === "real" && isStep3));
+  document.querySelector("#profitGoalSection")?.classList.toggle("is-hidden", !(mode !== "real" && isStep3));
   const heading = document.querySelector("#profitGoalHeading");
   if (heading) heading.textContent = "Margem desejada";
   const hint = document.querySelector("#calcModeMicrocopy");

--- a/index.html
+++ b/index.html
@@ -215,8 +215,8 @@
 
           <section class="formBlock wizardStep is-hidden" data-step="3" id="profitGoalSection">
             <div class="formBlock__head">
-              <h3 id="profitGoalHeading">Meta de lucro</h3>
-              <p>Defina sua meta em valor fixo ou em percentual.</p>
+              <h3 id="profitGoalHeading">Margem desejada</h3>
+              <p>Defina sua margem em valor fixo ou em percentual.</p>
             </div>
 
             <div class="field">


### PR DESCRIPTION
### Motivation
- Corrigir o bug em que o bloco “Margem desejada” aparecia duplicado (Passo 2 e Passo 3) quando o usuário escolhia o Modo 2 (Preço Ideal).
- Garantir que cada `wizardStep` contenha apenas seu conteúdo e que o Passo 2 mostre somente a seleção de marketplaces e ações de navegação.

### Description
- Atualizei `index.html` para padronizar o heading do bloco de meta/profit para `Margem desejada` dentro do `#profitGoalSection` (Passo 3) sem alterar estilos ou layout. (`index.html`)
- Ajustei `toggleUxModeSections()` em `assets/js/main.js` para levar em conta o `wizardStep === 3` ao alternar visibilidade de `#mode1PriceSection` e `#profitGoalSection`, evitando que conteúdos do Passo 3 sejam exibidos enquanto o usuário estiver no Passo 2. (`assets/js/main.js`)
- Mudança intencionalmente estrutural/condicional apenas; não alterei estilos, paleta ou lógica de cálculo.

### Testing
- Servi a aplicação localmente com `python3 -m http.server` e executei um script Playwright que percorre o fluxo (Modo Ideal → Passo 2 → selecionar marketplace → Continuar → Passo 3), e a verificação passou: Passo 2 não mostra “Margem desejada” e Passo 3 mostra apenas uma vez. (sucesso)
- Rodei checagens estruturais via `python3` que confirmam `id="profitGoalSection"` existe apenas uma vez e que o texto `Margem desejada` aparece somente no Passo 3 (sucesso).
- Testes intermediários de automação tiveram algumas tentativas de timeout/ajuste, porém a validação final com Playwright e asserções de estrutura passaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ee6375b28833293c9c6eabf866be1)