### PR TITLE
Fix wizard start flow to always begin at mode selection (step 0)

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2745,12 +2745,24 @@ function renderMode1PriceInputs() {
 function toggleUxModeSections() {
   const mode = getCalcMode();
   const hasMode = Boolean(mode);
+  const mode1PriceSection = document.querySelector("#mode1PriceSection");
+  const profitGoalSection = document.querySelector("#profitGoalSection");
+  const hint = document.querySelector("#calcModeMicrocopy");
+
+  if (!hasMode) {
+    mode1PriceSection?.classList.add("is-hidden");
+    profitGoalSection?.classList.add("is-hidden");
+    if (hint) hint.textContent = "";
+    return;
+  }
+
+  const isStep2 = wizardStep === 2;
   const isStep3 = wizardStep === 3;
-  document.querySelector("#mode1PriceSection")?.classList.toggle("is-hidden", !(hasMode && mode === "real" && isStep3));
-  document.querySelector("#profitGoalSection")?.classList.toggle("is-hidden", !(hasMode && mode === "ideal" && isStep3));
+  mode1PriceSection?.classList.toggle("is-hidden", !(mode === "real" && isStep2));
+  profitGoalSection?.classList.toggle("is-hidden", !(mode === "ideal" && isStep3));
   const heading = document.querySelector("#profitGoalHeading");
   if (heading) heading.textContent = "Margem desejada";
-  const hint = document.querySelector("#calcModeMicrocopy");
+
   if (hint) {
     hint.textContent = mode === "real"
       ? "Preço pode variar por marketplace. Preencha o valor correspondente a cada canal."
@@ -2784,6 +2796,10 @@ function setWizardStep(step) {
 }
 
 function renderWizardUI() {
+  if (!getCalcMode() && wizardStep > 0) {
+    wizardStep = 0;
+  }
+
   document.querySelectorAll(".wizardStep").forEach((el) => {
     const step = Number(el.dataset.step || 0);
     el.classList.toggle("is-hidden", step !== wizardStep);
@@ -2926,11 +2942,13 @@ function initUxRefactor() {
     el.checked = false;
   });
 
-  toggleUxModeSections();
-
   uxRecalc();
   setWizardStep(0);
   renderWizardUI();
+  window.setTimeout(() => {
+    setWizardStep(0);
+    renderWizardUI();
+  }, 0);
 }
 
 function initApp() {


### PR DESCRIPTION
### Motivation
- The wizard sometimes skipped the initial mode-selection and jumped to later steps when shared/legacy state or other UI boot code pushed `wizardStep` > 0, causing the "modo" to disappear and breaking the expected flow.
- The intent is to guarantee the UX always boots on the mode selection screen and prevent the user from being on steps > 0 without a selected mode.

### Description
- Added a guard at the top of `renderWizardUI()` that forces `wizardStep = 0` when `getCalcMode()` returns empty and `wizardStep > 0`, ensuring the wizard cannot render a later step without a selected mode.
- Reworked `toggleUxModeSections()` so that when no mode is selected it hides `#mode1PriceSection` and `#profitGoalSection`, clears `#calcModeMicrocopy`, and returns immediately, and otherwise shows `#mode1PriceSection` only for `mode === "real"` on `wizardStep === 2` and `#profitGoalSection` only for `mode === "ideal"` on `wizardStep === 3`, preserving microcopy per mode.
- Hardened `initUxRefactor()` boot behavior by unchecking all `input[name="calcMode"]` radios on boot, running `uxRecalc()`, setting and rendering `setWizardStep(0)`, and forcing the same reset again on the next tick with `setTimeout(..., 0)` to prevent legacy code from pushing the wizard forward.

### Testing
- Ran a JS syntax check with `node --check assets/js/main.js` which passed successfully.
- Served the app with `python3 -m http.server` and executed Playwright automation (Firefox) that validated the required flows: hard refresh shows step 0, clicking a mode card selects the radio and advances to step 1, step 1 continue requires ≥1 marketplace, REAL shows `#mode1PriceSection` on step 2, IDEAL shows `#profitGoalSection` on step 3, and `#wizardNewCalc` clears mode and returns to step 0; these checks passed.
- Attempted the same Playwright run on Chromium but it failed due to a browser crash in the environment (non-code related), however the Firefox run covered the functional validations and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ef72da38083328bec55da3e96513e)