### PR TITLE
Scope marketplace chip checkbox styles and improve chip layout/responsiveness

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -884,13 +884,51 @@ input::placeholder{color:#95a0b2}
   flex-wrap:wrap;
 }
 .marketplaceChip{
+  display:inline-flex;
+  align-items:center;
+  gap:10px;
+  min-height:44px;
   border-radius:999px;
   border:1px solid rgba(148,163,184,.45);
   background:linear-gradient(180deg,rgba(255,255,255,.9),rgba(248,250,252,.76));
   box-shadow:0 6px 14px rgba(15,23,42,.06);
-  padding:10px 15px;
+  padding:10px 14px;
 }
 .marketplaceChip:hover{box-shadow:0 10px 20px rgba(15,23,42,.12);border-color:color-mix(in srgb,var(--accent) 42%, transparent)}
+.marketplaceChip input[type="checkbox"]{
+  appearance:none !important;
+  -webkit-appearance:none !important;
+  width:16px !important;
+  height:16px !important;
+  min-width:16px !important;
+  min-height:16px !important;
+  border:1.5px solid var(--stroke) !important;
+  border-radius:4px !important;
+  background:transparent !important;
+  margin:0 !important;
+  flex:0 0 auto !important;
+  display:inline-block !important;
+}
+.marketplaceChip input[type="checkbox"]:checked{
+  background:var(--accent) !important;
+  border-color:var(--accent) !important;
+}
+.marketplaceChip input[type="checkbox"]:checked::after{
+  content:"" !important;
+  display:block !important;
+  width:6px !important;
+  height:10px !important;
+  border:2px solid #fff !important;
+  border-top:0 !important;
+  border-left:0 !important;
+  transform:translate(4px,1px) rotate(45deg) !important;
+}
+.marketplaceChip span{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  min-width:0;
+}
 .marketplaceChip:has(input:checked){
   border-color:color-mix(in srgb,var(--accent) 58%, transparent);
   background:linear-gradient(180deg,color-mix(in srgb,var(--accent) 16%, #fff),color-mix(in srgb,var(--accent) 7%, #fff));
@@ -932,6 +970,7 @@ input::placeholder{color:#95a0b2}
   .marketplaceSelector{
     flex-wrap:nowrap;
     overflow-x:auto;
+    scrollbar-width:thin;
     scroll-snap-type:x mandatory;
     -webkit-overflow-scrolling:touch;
     mask-image:linear-gradient(to right,transparent,black 10%,black 90%,transparent);


### PR DESCRIPTION
### Motivation
- Fix visual bug where a large square (oversized checkbox) appears inside marketplace chips because global input rules leaked into chip checkboxes.  
- The problematic global rules were `input,select { width:100%; padding:... }` and `button,input,select,a.btn { min-height:46px }` in `assets/css/styles.css`, which affected `input[type="checkbox"]`.  
- Ensure chips remain visually consistent, aligned (icon + name), and responsive on desktop and mobile without changing global checkbox behavior.

### Description
- Added scoped checkbox reset and styling for chip checkboxes in `assets/css/styles.css` under `.marketplaceChip input[type="checkbox"]` to neutralize global styles and force a compact 16x16 appearance.  
- Implemented checked-state visuals (`:checked` background/border and a simple `::after` tick) and kept these rules `!important` to override leaked globals safely inside chips.  
- Updated chip layout to `inline-flex`, aligned content with `gap` and adjusted padding/min-height, and refined mobile selector behavior (preserve horizontal carousel and add `scrollbar-width: thin`).

### Testing
- Ran targeted code search with `rg` to find affected selectors and confirm presence of global `input` rules (success).  
- Ran `git diff --check` to validate there are no diff/whitespace issues (success).  
- Attempted automated visual validation via Playwright/screenshots and a local static server but screenshots could not be produced in this environment due to local file/server access limitations (visual check could not complete here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f01f8f6e08332a60f489f0d4c9afb)