### PR TITLE
Enviar PDF somente por e‑mail e incluir preços ideais no anexo

### DIFF
--- a/api/lead.php
+++ b/api/lead.php
@@ -42,6 +42,7 @@ $userAgent = trim((string) ($input['user_agent'] ?? ''));
 $resultado = $input['resultado'] ?? [];
 $precoMinimo = (float) ($resultado['precoMinimo'] ?? 0);
 $precoIdeal = (float) ($resultado['precoIdeal'] ?? 0);
+$marketplacePrices = is_array($resultado['marketplaces'] ?? null) ? $resultado['marketplaces'] : [];
 $utm = $input['utm'] ?? [];
 
 if ($company !== '') {
@@ -80,9 +81,9 @@ try {
     respond(['success' => false, 'message' => 'lead_not_saved'], 500);
 }
 
-$summaryBody = buildSummaryEmailBody($nome, $marketplace, $precoMinimo, $precoIdeal);
+$summaryBody = buildSummaryEmailBody($nome, $marketplace, $precoMinimo, $precoIdeal, $marketplacePrices);
 $subject = 'Seu resumo de precificação — ' . $marketplace;
-$pdfContent = buildSummaryPdf($nome, $marketplace, $precoMinimo, $precoIdeal);
+$pdfContent = buildSummaryPdf($nome, $marketplace, $precoMinimo, $precoIdeal, $marketplacePrices);
 $attachments = [[
     'content' => $pdfContent,
     'name' => 'resumo-precificacao.pdf',

--- a/index.html
+++ b/index.html
@@ -544,7 +544,7 @@
             </div>
             <div id="stickySummaryContent" class="stickySummary__content">Preencha os dados para ver o resumo principal.</div>
             <div class="stickySummary__actions">
-              <button id="stickyExportPDF" class="btn btn--primary" data-action="export-pdf" data-from="sticky" type="button">Exportar PDF</button>
+              <button id="stickyLeadCapture" class="btn btn--primary" data-action="focus-lead-capture" type="button">Receber PDF por e-mail</button>
               <button id="stickyShare" class="btn btn--ghost" data-action="share-whatsapp" type="button">Compartilhar</button>
             </div>
           </aside>
@@ -552,7 +552,6 @@
           <button id="stickyOpen" class="stickyOpen" type="button">Resumo</button>
 
           <div id="shareBox" class="shareBox"></div>
-          <div id="pdfButtonContainer" style="margin-top: 15px;"></div>
 
           <div class="hr"></div>
 
@@ -708,7 +707,6 @@
     (function loadVersionedScripts() {
       const scripts = [
         "assets/js/storage.js",
-        "assets/js/pdf-export.js",
         "assets/js/main.js"
       ];
 


### PR DESCRIPTION
### Motivation
- Corrigir o PDF gerado que não trazia os preços ideais por marketplace e ajustar o fluxo para que o PDF seja entregue apenas por e‑mail, preservando toda a lógica e configuração de envio de e‑mail existente.
- Pequena nota de processo: nenhum skill externo foi usado durante essa alteração (nenhuma das skills listadas foi necessária para implementar o ajuste).

### Description
- Remove a exportação direta de PDF na interface e substitui o CTA do resumo por um botão `Receber PDF por e‑mail` que abre/foca o formulário de captura (adiciona ação `focus-lead-capture` e remove o fluxo `export-pdf`/`runExportPDF`).
- No front-end `assets/js/main.js` adiciona `leadCaptureState.marketplacePrices`, popula essa lista após o `recalc` e passa `resultado.marketplaces` no payload ao submeter o lead para o backend.
- No backend `api/lead.php` aceita `resultado.marketplaces` do payload e encaminha essa lista para os builders de e‑mail/PDF sem alterar o mecanismo de envio SMTP/fallback.
- Em `api/email_sender.php` adiciona `sanitizeMarketplacePrices()` e atualiza `buildSummaryEmailBody()` e `buildSummaryPdf()` para incluir a lista de `preços ideais por marketplace` no corpo do e‑mail e no PDF anexado, mantendo a API de anexos e o formato do PDF gerado.

### Testing
- Verificações de sintaxe PHP foram executadas com `php -l api/lead.php` e `php -l api/email_sender.php` e ambos retornaram sem erros.
- Verificação de JavaScript foi executada com `node --check assets/js/main.js` e passou sem erros.
- Foi tentada uma captura de tela via browser (`playwright`) para validar a interface, mas a execução local retornou `ERR_EMPTY_RESPONSE` no ambiente de teste; por isso o fluxo visual não foi capturado automaticamente.
- Observação: envio real de e‑mail/SMTP não foi executado no ambiente de CI; a lógica de envio e anexos foi preservada e apenas o conteúdo do anexo foi enriquecido com os preços por marketplace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a03c4c39b083329ae28322bca63a5e)