### PR TITLE
Simplifica cálculo para foco em preço de venda por marketplace

### DIFF
--- a/api/email_sender.php
+++ b/api/email_sender.php
@@ -62,8 +62,6 @@ function sanitizeMarketplaceSummaries(array $items): array
 function buildSummaryEmailBody(string $nome, string $marketplace, float $precoMinimo, float $precoIdeal, array $marketplacePrices = []): string
 {
     $nomeSeguro = $nome !== '' ? htmlspecialchars($nome, ENT_QUOTES, 'UTF-8') : '';
-    $marketplaceSeguro = htmlspecialchars($marketplace, ENT_QUOTES, 'UTF-8');
-
     $saudacao = $nomeSeguro !== '' ? "Olá, {$nomeSeguro}!" : 'Olá!';
     $sanitizedPrices = sanitizeMarketplaceSummaries($marketplacePrices);
 
@@ -72,30 +70,21 @@ function buildSummaryEmailBody(string $nome, string $marketplace, float $precoMi
         $priceRows .= '<tr>'
             . '<td style="padding:6px 8px;border:1px solid #e5e7eb">' . htmlspecialchars($item['title'], ENT_QUOTES, 'UTF-8') . '</td>'
             . '<td style="padding:6px 8px;border:1px solid #e5e7eb">' . formatBrl((float) $item['precoIdeal']) . '</td>'
-            . '<td style="padding:6px 8px;border:1px solid #e5e7eb">' . formatBrl((float) $item['lucro']) . '</td>'
-            . '<td style="padding:6px 8px;border:1px solid #e5e7eb">' . number_format((float) $item['margem'], 2, ',', '.') . '%</td>'
             . '</tr>';
     }
 
     $priceListHtml = $priceRows !== ''
-        ? '<p style="margin:0 0 10px"><strong>Resumo completo por marketplace:</strong></p>'
+        ? '<p style="margin:0 0 10px"><strong>Preço de venda por marketplace:</strong></p>'
             . '<table style="border-collapse:collapse;width:100%;margin:0 0 20px">'
             . '<thead><tr>'
             . '<th style="text-align:left;padding:6px 8px;border:1px solid #e5e7eb;background:#f9fafb">Marketplace</th>'
-            . '<th style="text-align:left;padding:6px 8px;border:1px solid #e5e7eb;background:#f9fafb">Preço ideal</th>'
-            . '<th style="text-align:left;padding:6px 8px;border:1px solid #e5e7eb;background:#f9fafb">Lucro</th>'
-            . '<th style="text-align:left;padding:6px 8px;border:1px solid #e5e7eb;background:#f9fafb">Margem</th>'
+            . '<th style="text-align:left;padding:6px 8px;border:1px solid #e5e7eb;background:#f9fafb">Preço de venda</th>'
             . '</tr></thead><tbody>' . $priceRows . '</tbody></table>'
         : '';
 
     return '<div style="font-family:Arial,sans-serif;max-width:580px;margin:0 auto;padding:24px;color:#111827;line-height:1.5">'
         . '<h2 style="margin:0 0 16px;font-size:22px;color:#111827">Seu resumo de precificação</h2>'
         . '<p style="margin:0 0 16px">' . $saudacao . '</p>'
-        . '<ul style="padding-left:18px;margin:0 0 20px">'
-        . '<li><strong>Marketplace de referência:</strong> ' . $marketplaceSeguro . '</li>'
-        . '<li><strong>Preço mínimo:</strong> ' . formatBrl($precoMinimo) . '</li>'
-        . '<li><strong>Preço ideal (maior lucro):</strong> ' . formatBrl($precoIdeal) . '</li>'
-        . '</ul>'
         . $priceListHtml
         . '<p style="margin:0 0 20px"><a href="https://precificacao.rafamaceno.com.br">https://precificacao.rafamaceno.com.br</a></p>'
         . '<p style="margin:24px 0 0">Rafa Maceno</p>'
@@ -124,19 +113,15 @@ function buildSummaryPdf(string $nome, string $marketplace, float $precoMinimo, 
         '',
         $firstLine,
         '',
-        'Marketplace de referencia: ' . normalizePdfText($marketplace),
-        'Preco minimo: ' . normalizePdfText(formatBrl($precoMinimo)),
-        'Preco ideal (maior lucro): ' . normalizePdfText(formatBrl($precoIdeal)),
+        'Preco de venda por marketplace',
         '',
     ];
 
     if ($sanitizedPrices !== []) {
-        $lines[] = 'Resumo completo por marketplace:';
+        $lines[] = 'Preco de venda por marketplace:';
         foreach ($sanitizedPrices as $item) {
             $lines[] = '- ' . normalizePdfText($item['title']);
-            $lines[] = '  Preco ideal: ' . normalizePdfText(formatBrl((float) $item['precoIdeal']));
-            $lines[] = '  Lucro: ' . normalizePdfText(formatBrl((float) $item['lucro']));
-            $lines[] = '  Margem: ' . normalizePdfText(number_format((float) $item['margem'], 2, ',', '.') . '%');
+            $lines[] = '  Preco de venda: ' . normalizePdfText(formatBrl((float) $item['precoIdeal']));
         }
         $lines[] = '';
     }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -686,33 +686,6 @@ function compareCardHTML(title, data) {
   `;
 }
 
-function updateStickySummary(results) {
-  const wrap = document.querySelector("#stickySummaryContent");
-  if (!wrap) return;
-
-  if (!Array.isArray(results) || !results.length) {
-    wrap.textContent = "Preencha os dados para ver o resumo estratégico.";
-    return;
-  }
-
-  const sorted = [...results].sort((a, b) => (b?.profitBRL || 0) - (a?.profitBRL || 0));
-  const first = sorted[0];
-  const second = sorted[1] || sorted[0];
-  const diffPct = (first?.profitBRL || 0) > 0
-    ? (((first?.profitBRL || 0) - (second?.profitBRL || 0)) / (first?.profitBRL || 1)) * 100
-    : 0;
-
-  let indicator = "🟡 Apertado";
-  if (diffPct >= 10) indicator = "🟢 Saudável";
-  if (diffPct < 3) indicator = "🔴 Risco";
-
-  wrap.innerHTML = `
-    <div><strong>Marketplace mais lucrativo:</strong> ${first.title}</div>
-    <div><strong>Diferença percentual (1º x 2º):</strong> ${diffPct.toFixed(2)}%</div>
-    <div><strong>Indicador:</strong> ${indicator}</div>
-  `;
-}
-
 function updateReportRoot() {
   const reportRoot = document.querySelector("#reportRoot");
   const results = document.querySelector("#results");
@@ -884,7 +857,7 @@ function resultCardHTML(
 
 
 async function shareFallback() {
-  const summaryText = document.querySelector("#stickySummaryContent")?.innerText?.trim() || "Resumo indisponível.";
+  const summaryText = "Confira seus preços por marketplace em https://precificacao.rafamaceno.com.br";
   try {
     await navigator.clipboard.writeText(summaryText);
     trackGA4Event("copy_link", { section: "summary_text" });
@@ -1002,36 +975,6 @@ function bindTooltipSystem() {
     closeTooltip();
   });
 }
-
-function bindStickySummaryVisibility() {
-  const sticky = document.querySelector("#stickySummary");
-  const closeBtn = document.querySelector("#stickyClose");
-  const openBtn = document.querySelector("#stickyOpen");
-  if (!sticky || !closeBtn || !openBtn) return;
-
-  if (window.matchMedia("(max-width: 768px)").matches && localStorage.getItem("stickyHidden") === null) {
-    localStorage.setItem("stickyHidden", "1");
-  }
-
-  const applyState = () => {
-    const hidden = localStorage.getItem("stickyHidden") === "1";
-    sticky.classList.toggle("is-hidden", hidden);
-    openBtn.classList.toggle("is-visible", hidden);
-  };
-
-  closeBtn.addEventListener("click", () => {
-    localStorage.setItem("stickyHidden", "1");
-    applyState();
-  });
-
-  openBtn.addEventListener("click", () => {
-    localStorage.setItem("stickyHidden", "0");
-    applyState();
-  });
-
-  applyState();
-}
-
 
 function renderRankingInsights(items) {
   const el = document.querySelector("#rankingInsights");
@@ -1725,14 +1668,6 @@ function recalc(options = {}) {
     shouldDisplay: cost > 0,
     computedResults
   });
-  updateStickySummary([
-    { title: "Shopee", received: shopee.received, profitBRL: shopee.profitBRL, profitPctReal: shopee.profitPctReal },
-    { title: "TikTok Shop", received: tiktok.received, profitBRL: tiktok.profitBRL, profitPctReal: tiktok.profitPctReal },
-    { title: "SHEIN", received: shein.received, profitBRL: shein.profitBRL, profitPctReal: shein.profitPctReal },
-    ...(amazonDbaEnabled && amazonData ? [{ title: "Amazon (DBA)", received: amazonData.result.received, profitBRL: amazonData.result.profitBRL, profitPctReal: amazonData.result.profitPctReal }] : []),
-    { title: "Mercado Livre — Clássico", received: mlClassic.r.received, profitBRL: mlClassic.r.profitBRL, profitPctReal: mlClassic.r.profitPctReal },
-    { title: "Mercado Livre — Premium", received: mlPremium.r.received, profitBRL: mlPremium.r.profitBRL, profitPctReal: mlPremium.r.profitPctReal }
-  ]);
   updateReportRoot();
   trackPerfilTicket(shopee.price);
   trackGA4Event("recalc", { section: source || "auto", value: Number(shopee.price || 0) });
@@ -1741,13 +1676,6 @@ function recalc(options = {}) {
   const y = document.querySelector("#year");
   if (y) y.textContent = String(new Date().getFullYear());
 
-  if (window.matchMedia("(max-width: 768px)").matches && source === "manual") {
-    localStorage.setItem("stickyHidden", "0");
-    const sticky = document.querySelector("#stickySummary");
-    const openBtn = document.querySelector("#stickyOpen");
-    sticky?.classList.remove("is-hidden");
-    openBtn?.classList.remove("is-visible");
-  }
 }
 
 
@@ -2970,7 +2898,6 @@ function initApp() {
   bindMobileMenu();
   bindInputTracking();
   bindTooltipSystem();
-  bindStickySummaryVisibility();
   bindSmoothScroll();
   bindSegmentMenuActiveState();
   bindBulk();

--- a/index.html
+++ b/index.html
@@ -537,20 +537,6 @@
 
           <div id="reportRoot" class="reportRoot" aria-live="polite"></div>
 
-          <aside id="stickySummary" class="stickySummary" aria-live="polite">
-            <div class="stickySummary__top">
-              <h3>Resumo Estratégico</h3>
-              <button id="stickyClose" class="stickySummary__close" type="button" aria-label="Fechar resumo">✕</button>
-            </div>
-            <div id="stickySummaryContent" class="stickySummary__content">Preencha os dados para ver o resumo principal.</div>
-            <div class="stickySummary__actions">
-              <button id="stickyLeadCapture" class="btn btn--primary" data-action="focus-lead-capture" type="button">Receber PDF por e-mail</button>
-              <button id="stickyShare" class="btn btn--ghost" data-action="share-whatsapp" type="button">Compartilhar</button>
-            </div>
-          </aside>
-
-          <button id="stickyOpen" class="stickyOpen" type="button">Resumo</button>
-
           <div id="shareBox" class="shareBox"></div>
 
           <div class="hr"></div>


### PR DESCRIPTION
### Motivation
- O produto deve priorizar o norte: informar por qual preço o produto precisa ser vendido em cada plataforma, sem diagnóstico estratégico adicional.

### Description
- Removi o bloco visual de “Resumo Estratégico” e o botão de abrir/fechar em `index.html` para deixar a interface focada nos cards de resultado por marketplace.
- Eliminei a lógica JavaScript associada ao resumo (funções e invocações relacionadas a `updateStickySummary` e `bindStickySummaryVisibility`) e ajustei o fallback de compartilhamento em `assets/js/main.js` para copiar uma mensagem direta sobre preços por marketplace.
- Atualizei a montagem do e-mail e do PDF em `api/email_sender.php` para listar apenas o `Preço de venda por marketplace`, removendo as informações de `marketplace de referência`, `preço mínimo`, `preço ideal (maior lucro)` e as colunas de `lucro`/`margem` no resumo enviado ao lead.
- Mudanças principais aplicadas em: `index.html`, `assets/js/main.js`, `api/email_sender.php`.

### Testing
- Executado `node --check assets/js/main.js` e a verificação de sintaxe do JS retornou sucesso. (succeeded)
- Executado `php -l api/email_sender.php` para checar sintaxe do PHP e não foram encontrados erros. (succeeded)
- Geração de screenshot da interface via Playwright/Firefox para validação visual do resultado (artifact: `artifacts/remocao-resumo.png`) e execução concluída com sucesso. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0519f621c8332a23560ca069b17bf)