### PR TITLE
Fix mobile tap interaction on calculation mode cards

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -862,6 +862,8 @@ input::placeholder{color:#95a0b2}
   border:1px solid rgba(148,163,184,.34);
   background:linear-gradient(180deg,rgba(255,255,255,.86),rgba(248,250,252,.75));
   box-shadow:var(--shadow-sm);
+  touch-action:manipulation;
+  -webkit-tap-highlight-color:transparent;
 }
 .modeCard::before{
   content:"";
@@ -872,6 +874,7 @@ input::placeholder{color:#95a0b2}
   height:40px;
   border-radius:12px;
   background:linear-gradient(135deg,rgba(15,157,146,.18),rgba(124,58,237,.12));
+  pointer-events:none;
 }
 .modeCard strong{font-size:19px;position:relative;z-index:1}
 .modeCard p{color:#5f7086}


### PR DESCRIPTION
### Motivation
- Mobile taps on the calculation mode cards could be ignored because a decorative pseudo-element or default touch behavior intercepted/blocked the touch, preventing users from selecting a mode on phones.

### Description
- Adjusted `assets/css/styles.css` by adding `touch-action: manipulation` and `-webkit-tap-highlight-color: transparent` to `.modeCard` and `pointer-events: none` to `.modeCard::before` so taps reliably reach the button.

### Testing
- Launched a local server with `python3 -m http.server 4173` and ran a Playwright mobile viewport test that tapped `.modeCard[data-mode="ideal"]`, observed the wizard progress change from `Passo 0 de 4` to `Passo 1 de 4`, and captured screenshots; the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a96d303c833283fa82f48bfc3a2e)