### PR TITLE
Corrige seleção de modo no mobile

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2707,6 +2707,10 @@ function setWizardStep(step) {
 }
 
 function renderWizardUI() {
+  if (wizardStep === 0 && getCalcMode()) {
+    wizardStep = 1;
+  }
+
   if (!getCalcMode() && wizardStep > 0) {
     wizardStep = 0;
   }
@@ -2787,17 +2791,30 @@ function initUxRefactor() {
     document.querySelector("#profitFieldPCT")?.classList.remove("is-hidden");
   }
 
-  document.querySelector("#calcModeCards")?.addEventListener("click", (event) => {
-    const card = event.target.closest(".modeCard");
-    if (!card) return;
-    const mode = card.dataset.mode;
+  const selectCalcMode = (mode) => {
+    if (!mode) return;
     const real = document.querySelector("#mode_real");
     const ideal = document.querySelector("#mode_ideal");
-    if (mode === "real" && real) real.checked = true;
-    if (mode === "ideal" && ideal) ideal.checked = true;
-    toggleUxModeSections();
+    if (mode === "real" && real) {
+      real.checked = true;
+      real.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+    if (mode === "ideal" && ideal) {
+      ideal.checked = true;
+      ideal.dispatchEvent(new Event("change", { bubbles: true }));
+    }
     setWizardStep(1);
-  });
+  };
+
+  const calcModeCards = document.querySelector("#calcModeCards");
+  const handleCalcModeCardInteraction = (event) => {
+    const card = event.target.closest?.(".modeCard");
+    if (!card) return;
+    selectCalcMode(card.dataset.mode);
+  };
+
+  calcModeCards?.addEventListener("click", handleCalcModeCardInteraction);
+  calcModeCards?.addEventListener("pointerup", handleCalcModeCardInteraction);
 
   document.querySelector("#mode1PriceInputs")?.addEventListener("input", (event) => {
     const input = event.target.closest("[data-ux-price-marketplace]");
@@ -2824,6 +2841,10 @@ function initUxRefactor() {
   });
 
   document.querySelectorAll('input[name="calcMode"]').forEach((el) => el.addEventListener("change", () => {
+    if (wizardStep === 0 && getCalcMode()) {
+      setWizardStep(1);
+      return;
+    }
     toggleUxModeSections();
     renderWizardUI();
   }));


### PR DESCRIPTION
### Motivation
- Corrigir o problema onde, em dispositivos móveis, tocar nos cards de modo ("Lucro Real" / "Preço Ideal") não marcava corretamente o rádio nem avançava o wizard para o passo seguinte. 

### Description
- Centraliza a lógica de seleção em `selectCalcMode(mode)` que marca o rádio correspondente e dispara um evento `change` para manter a UI sincronizada. 
- Substitui escuta apenas em `click` por handlers que também respondem a interação touch usando `pointerup` no container `#calcModeCards`. 
- Ajusta `renderWizardUI` para avançar automaticamente para o passo 1 quando já existe um modo selecionado e atualiza o listener de `change` dos rádios para avançar do passo 0 para o passo 1 quando necessário. 
- Arquivo modificado: `assets/js/main.js`.

### Testing
- Rodou `node --check assets/js/main.js` sem erros. 
- Levantou servidor local com `python3 -m http.server 4173` para testes de integração. 
- Validou automaticamente com Playwright em viewport mobile (`has_touch`/`is_mobile`) confirmando que o radio (`#mode_ideal`) é marcado ao tocar o card, o texto de progresso passa de `Passo 0` para `Passo 1`, e que a seção do passo 0 fica oculta enquanto a do passo 1 fica visível, com todos os checks passando.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1aea6bd008332a1b211a798a6af63)