### PR TITLE
Improve mobile UX for marketplace selector and wizard action buttons

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1296,3 +1296,53 @@ body.theme-dark .mpLogoWrap{
 
   .mpName{max-width:44vw}
 }
+
+/* Mobile UX fix: keep step 2 marketplaces fully visible and buttons more fluid */
+@media (max-width:768px){
+  #marketplaceSelector.marketplaceSelector{
+    display:grid;
+    grid-template-columns:repeat(2,minmax(0,1fr));
+    gap:8px;
+    overflow:visible;
+    padding-bottom:0;
+  }
+
+  #marketplaceSelector .marketplaceChip{
+    width:100%;
+    max-width:none;
+    min-width:0;
+    padding:10px 12px;
+  }
+
+  #marketplaceSelector .mpName{
+    max-width:none;
+    white-space:normal;
+    line-height:1.2;
+  }
+
+  .wizardActions{
+    flex-direction:row;
+    flex-wrap:wrap;
+    justify-content:flex-end;
+    gap:8px;
+  }
+
+  .wizardActions .btn{
+    width:auto;
+    flex:0 1 auto;
+    min-width:132px;
+    max-width:48%;
+    min-height:40px;
+    padding:9px 12px;
+    font-size:14px;
+    border-radius:11px;
+  }
+}
+
+@media (max-width:420px){
+  #marketplaceSelector.marketplaceSelector{grid-template-columns:1fr;}
+  .wizardActions .btn{
+    flex:1 1 auto;
+    max-width:none;
+  }
+}


### PR DESCRIPTION
### Motivation
- Step 2 marketplace chips and wizard action buttons were not fully visible or fluid on small screens, causing overflow and awkward wrapping. 
- The change aims to make marketplace entries easier to read and actions easier to tap on narrow viewports.

### Description
- Updated `assets/css/styles.css` to add mobile-only responsive rules that convert `#marketplaceSelector.marketplaceSelector` to a CSS grid with two columns and controlled gaps. 
- Adjusted `.marketplaceChip` and `.mpName` on small screens to remove max-width constraints, allow normal wrapping, and set improved padding and line-height. 
- Made `.wizardActions` and `.wizardActions .btn` more flexible with wrapping, min/max widths, padding, font-size, and a mobile-specific override for single-column buttons under `@media (max-width:420px)`.

### Testing
- Ran CSS linting with `stylelint` on the changed file and it completed successfully. 
- Built frontend assets with `npm run build` to validate CSS output and the build succeeded. 
- Ran the project's automated test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b4e359d88332a096ff1e02f3c11c)