### PR TITLE
Fix wizard back button behavior on step 1

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2796,10 +2796,6 @@ function setWizardStep(step) {
 }
 
 function renderWizardUI() {
-  if (wizardStep === 0 && getCalcMode()) {
-    wizardStep = 1;
-  }
-
   if (!getCalcMode() && wizardStep > 0) {
     wizardStep = 0;
   }


### PR DESCRIPTION
### Motivation

- The wizard "Voltar" button on Step 1 could not return to Step 0 because `renderWizardUI()` forcibly advanced the UI to Step 1 when a calc mode was selected, causing a navigation loop.
- Make a minimal fix to restore expected Step N -> Step N-1 navigation without touching any pricing/financial logic or refactoring the wizard.

### Description

- Removed the auto-advance guard inside `renderWizardUI()` that forced `wizardStep = 1` when a calc mode was present, leaving the remaining step-guard `if (!getCalcMode() && wizardStep > 0) { wizardStep = 0; }` intact to preserve safety.
- Change is localized to `assets/js/main.js` and is intentionally minimal so no formulas, calculations, costs, commissions, taxes or pricing logic were modified.
- Accessibility was not changed because the back controls are already rendered as native `<button>` elements and keyboard/click behavior was preserved.

### Testing

- Ran an automated E2E Playwright script that loads the app and validated the navigation scenarios, and it passed: `Step 0 -> Step 1 -> Voltar => Step 0` for both `real` and `ideal` modes, and `Step 2 -> Voltar => Step 1` with input persistence confirmed.
- The Playwright run produced a verification screenshot at `artifacts/wizard-back-fix.png` and reported all boolean checks as `true` and the persisted `calcName` value as expected.
- No automated unit tests were changed and no financial formulas/calculations were executed or modified during the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a260a516a08332a3e9263d3593f3f3)