### PR TITLE
Melhora destaque e abertura padrão em Custos Extras

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -109,7 +109,7 @@ input:hover,select:hover{border-color:#b8c5d7}
 .formAccordion > :not(summary){padding:0 16px 16px}
 .formAccordion__intro{margin:0 0 10px;color:var(--muted);font-size:12px;line-height:1.4}
 
-.optionalAdjustments{border-color:#dbe4ef;background:linear-gradient(180deg,#ffffff,#f8fafc);box-shadow:none}
+.optionalAdjustments{border:2px solid var(--accent);background-color:var(--accent-soft);transition:border-color .3s ease,background-color .3s ease;box-shadow:none}
 .optionalAdjustments summary{font-size:15px}
 .optionalGroup{margin-top:12px;padding:12px;border:1px solid #e2e8f0;border-radius:12px;background:#fff}
 .optionalGroup h4{margin:0 0 8px;font-size:13px;color:#334155;letter-spacing:.02em;text-transform:uppercase}
@@ -126,7 +126,7 @@ input:hover,select:hover{border-color:#b8c5d7}
 
 
 .resultAccordion{overflow:hidden;padding:0;border:1px solid var(--stroke);border-radius:14px;background:#fff;box-shadow:var(--shadow-sm)}
-.resultAccordion summary{list-style:none;cursor:pointer;padding:14px 16px}
+.resultAccordion summary{list-style:none;cursor:pointer;padding:14px 16px;background-color:var(--surface);transition:background-color .3s ease}
 .resultAccordion summary::-webkit-details-marker{display:none}
 .resultAccordion__summaryMain{display:flex;align-items:center;justify-content:space-between;gap:12px}
 .resultAccordion__left{min-width:0;flex:1}
@@ -138,6 +138,8 @@ input:hover,select:hover{border-color:#b8c5d7}
 .resultAccordion .pill--subtle{display:inline-flex;margin-top:4px;font-size:11px;padding:2px 8px;border-radius:999px;border:1px solid var(--stroke);background:#f8fafc;color:#475569}
 .resultAccordion__body{max-height:0;overflow:hidden;padding:0 16px;opacity:0;border-top:0;transition:max-height .35s ease,opacity .25s ease,padding .2s ease,border-color .2s ease}
 .resultAccordion[open] .resultAccordion__body{max-height:900px;opacity:1;padding:0 16px 16px;border-top:1px solid var(--stroke)}
+.resultAccordion[open] summary{background-color:var(--accent-soft)}
+.resultAccordion summary:hover{background-color:var(--surface-soft)}
 .resultAccordion:hover{background:#f8fafc}
 .resultAccordion[open]{background:#fff}
 
@@ -1428,3 +1430,5 @@ body.theme-dark .marketplaceChip{
   margin: 8px 0 0;
   text-align: center;
 }
+
+.optionalAdjustments:hover{border-color:var(--accent);background-color:var(--surface-soft)}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2867,6 +2867,11 @@ function initUxRefactor() {
   buildMarketplaceSelector();
   renderMode1PriceInputs();
 
+  const optionalAdjustments = document.querySelector(".optionalAdjustments");
+  if (optionalAdjustments instanceof HTMLDetailsElement) {
+    optionalAdjustments.open = true;
+  }
+
   const profitValuePct = document.querySelector("#profitValuePct");
   const metaPercent = document.querySelector("#meta_percent");
   if (profitValuePct && metaPercent) {


### PR DESCRIPTION
### Motivation
- Melhorar a visibilidade e acessibilidade da seção “Custos Extras” (accordion `.optionalAdjustments`) para que os usuários a encontrem e entendam sem alterar nenhuma lógica de cálculo financeiro.

### Description
- Abre automaticamente o `<details class="optionalAdjustments">` na inicialização da UI definindo `optionalAdjustments.open = true` em `initUxRefactor()` (`assets/js/main.js`).
- Atualiza o estilo de `.optionalAdjustments` para borda `2px solid var(--accent)`, fundo `var(--accent-soft)` e transição visual (`border-color .3s`, `background-color .3s`) em `assets/css/styles.css`.
- Adiciona estado de hover para `.optionalAdjustments` com `background-color: var(--surface-soft)` para feedback visual.
- Ajusta o `summary` dos accordions de resultado (`.resultAccordion summary`) para usar `background-color: var(--surface)` por padrão, `transition: background-color .3s ease`, estado aberto com `var(--accent-soft)` e hover com `var(--surface-soft)` em `assets/css/styles.css`.

### Testing
- Verificações de localização com `rg` confirmaram as regras CSS e a atribuição `optionalAdjustments.open = true` (sucesso).
- Inicialização de servidor simples com `python3 -m http.server 4173` e `curl -I http://127.0.0.1:4173/index.html` retornou `200 OK` (sucesso).
- Captura visual via Playwright Chromium falhou no ambiente por crash/SIGSEGV (falha), enquanto Playwright WebKit completou a captura e gerou o screenshot em `artifacts/custos-extras.png` (sucesso).
- Testes automatizados de busca (`rg`) para confirmar as alterações de CSS/JS foram executados com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3244a36b88332a04b84bda99b3cf9)