### PR TITLE
Melhora layout mobile dos cards de escolha de modo

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1369,10 +1369,19 @@ body.theme-dark .marketplaceChip{
   .wizardProgress::after{left:10px;bottom:6px;font-size:11px;content:"Passo " attr(data-step-label);}
 
   .modeCards{grid-template-columns:1fr;gap:8px;}
-  .modeCard{padding:16px;min-height:110px;border-radius:14px;}
+  .modeCard{
+    padding:10px;
+    margin:5px;
+    min-height:110px;
+    border-radius:14px;
+    display:flex;
+    align-items:center;
+    gap:8px;
+  }
   .modeCard::before{width:28px;height:28px;top:10px;right:10px;border-radius:9px;}
-  .modeCard__check{top:10px;right:10px}
-  .modeCard strong{margin-bottom:4px;font-size:18px;line-height:1.2;}
+  .modeCard__check{top:10px;right:10px;width:24px;height:24px}
+  .modeCard__check svg{width:14px;height:14px;}
+  .modeCard strong{margin-bottom:4px;font-size:18px;line-height:1.2;margin-left:8px;font-weight:bold;}
   .modeCard p{font-size:14px;line-height:1.4;padding-right:4px;}
 
   .wizardActions{display:flex;flex-wrap:wrap;align-items:center;gap:8px;margin-top:10px;}


### PR DESCRIPTION
### Motivation
- Melhorar a experiência mobile da tela inicial de escolha de modo reduzindo espaços desnecessários e facilitando a leitura e o toque nos cartões de seleção.
- Manter intacta a lógica de negócio e a aparência desktop, aplicando alterações apenas na camada visual para breakpoint mobile (`max-width:768px`).

### Description
- Ajusta o bloco mobile dos cartões de modo em `assets/css/styles.css` reduzindo `padding` para `10px` e adicionando `margin: 5px` para aumentar a densidade visual sem afetar desktop.
- Torna os cartões de modo um layout inline mais tátil com `display:flex`, `align-items:center` e `gap:8px` para alinhar ícone e texto lateralmente.
- Reduz o tamanho do indicador de seleção com `modeCard__check` para `24px` e ajusta o `svg` interno para `14px` para melhor proporção em telas pequenas.
- Realça o título do cartão com `font-size:18px`, `margin-left:8px` e `font-weight:bold` para melhorar legibilidade e hierarquia visual.

### Testing
- Executado `rg`/buscas no CSS para localizar blocos relevantes; comandos rodaram e retornaram resultados esperados (buscas sem matches específicos retornaram código 1 quando apropriado). (succeeded)
- Servidor estático iniciado com `python3 -m http.server 4173 --directory /workspace/calculadora` para validação local da UI. (succeeded)
- Captura visual realizada via Playwright em viewport mobile (`390x844`) e artefato de screenshot gerado para inspeção manual. (succeeded)
- Mudança adicionada ao repositório com `git commit` do arquivo `assets/css/styles.css`. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a32639f14083328e961ac692ad3583)