### PR TITLE
Add simulation summary and result-transparency panels to final pricing steps

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -101,6 +101,19 @@ input:hover,select:hover{border-color:#b8c5d7}
 .formInfoDetails summary{font-size:13px;color:#334155;font-weight:600}
 .formInfoDetails p{margin:8px 0 0;padding:12px;border:1px solid var(--stroke);border-radius:12px;background:#f8fafc;color:var(--muted);font-size:12px}
 
+.simulationSummaryGrid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
+.summaryCard{border:1px solid var(--stroke);border-radius:12px;padding:12px;background:#fff}
+.summaryCard h4{margin:0 0 8px;font-size:13px}
+.summaryCard ul,.summaryCard ol{margin:0;padding-left:18px;display:grid;gap:6px}
+.summaryCard li{display:flex;justify-content:space-between;gap:8px;color:var(--muted);font-size:12px}
+.summaryCard li span{flex:1}
+.summaryCallout{padding:10px 12px;border:1px solid var(--stroke);border-radius:12px;background:#f8fafc;font-size:12px;color:var(--muted);margin:8px 0 12px}
+.resultSummaryGrid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
+.resultSummaryGrid h4{margin:0 0 8px;font-size:13px}
+.resultSummaryGrid ul{margin:0;padding-left:18px;display:grid;gap:6px}
+.resultSummaryGrid li{display:flex;justify-content:space-between;gap:8px;font-size:12px;color:var(--muted)}
+@media (max-width: 800px){.simulationSummaryGrid,.resultSummaryGrid{grid-template-columns:1fr}}
+
 .formAccordion{margin-top:14px;padding:0;border:1px solid #d7e0eb;border-radius:14px;background:linear-gradient(180deg,#fff,#fbfdff);overflow:hidden;box-shadow:0 4px 14px rgba(15,23,42,.04)}
 .formAccordion summary{list-style:none;display:flex;align-items:center;justify-content:space-between;padding:15px 16px;font-size:14px;font-weight:700;color:#0f172a}
 .formAccordion summary::-webkit-details-marker{display:none}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1720,6 +1720,15 @@ function recalc(options = {}) {
 
   const state = { marketplaces: marketplaceState, cost, taxPct, shopeeAntecipa, computedResults };
 
+  LAST_CALC_CONTEXT = {
+    cost,
+    taxPct,
+    adv,
+    computedResults
+  };
+  renderSimulationSummary(buildSimulationSummaryContext());
+  renderResultTransparencySummary(LAST_CALC_CONTEXT);
+
   if (calcMode !== "real") {
     const basicResults = computeForAllMarketplaces({
       cost,
@@ -2781,6 +2790,7 @@ let UX_SELECTED_MARKETPLACES = UX_MARKETPLACES.map((mp) => mp.key);
 const UX_PRICE_VALUES = {};
 let UX_RECALC_TIMER = null;
 let wizardStep = 0;
+let LAST_CALC_CONTEXT = null;
 
 function getCalcMode() {
   return document.querySelector('input[name="calcMode"]:checked')?.value || "";
@@ -2874,6 +2884,137 @@ function toggleUxModeSections() {
       ? "Preço pode variar por marketplace. Preencha o valor correspondente a cada canal."
       : "Vamos calcular o preço ideal por marketplace com base na margem informada.";
   }
+}
+
+function formatPct(value) {
+  return `${(Math.max(0, Number(value) || 0) * 100).toFixed(2)}%`;
+}
+
+function buildSimulationSummaryContext() {
+  const mode = getCalcMode();
+  const cost = Math.max(0, toNumber(document.querySelector("#cost")?.value));
+  const taxPct = clamp(toNumber(document.querySelector("#tax")?.value), 0, 99) / 100;
+  const profitType = document.querySelector("#profitType")?.value || "brl";
+  const profitValue = Math.max(0, toNumber(document.querySelector("#profitValue")?.value));
+  const adv = getAdvancedVars();
+  const selectedKeys = getSelectedMarketplaces();
+
+  const mlEnabled = document.querySelector("#mlCommissionToggle")?.checked;
+  const mlClassicPct = (mlEnabled ? toNumber(document.querySelector("#mlClassicPct")?.value) : 14) / 100;
+  const mlPremiumPct = (mlEnabled ? toNumber(document.querySelector("#mlPremiumPct")?.value) : 19) / 100;
+
+  const perMarketplace = selectedKeys.map((key) => {
+    if (key === "mlClassic") return { key, label: "Mercado Livre — Clássico", commissionPct: mlClassicPct, affiliatePct: adv.affiliate.ml };
+    if (key === "mlPremium") return { key, label: "Mercado Livre — Premium", commissionPct: mlPremiumPct, affiliatePct: adv.affiliate.ml };
+    if (key === "tiktok") return { key, label: "TikTok Shop", commissionPct: TIKTOK.pct, affiliatePct: adv.affiliate.tiktok };
+    if (key === "shein") {
+      const enabled = document.querySelector("#sheinCommissionToggle")?.checked;
+      const category = enabled ? (document.querySelector("#sheinCategory")?.value || "other") : "other";
+      const pct = category === "female" ? SHEIN.pctFemale : SHEIN.pctOther;
+      return { key, label: "SHEIN", commissionPct: pct, affiliatePct: 0 };
+    }
+    if (key === "amazon") {
+      const enabled = document.querySelector("#amazonDbaToggle")?.checked || false;
+      const pct = Math.max(0, toNumber(document.querySelector("#amazonPct")?.value)) / 100;
+      return { key, label: enabled ? "Amazon (DBA)" : "Amazon (desativado)", commissionPct: pct, affiliatePct: adv.affiliate.amazon, disabled: !enabled };
+    }
+    return { key, label: "Shopee", commissionPct: SHOPEE_FAIXAS[0].pct, affiliatePct: adv.affiliate.shopee };
+  });
+
+  const totalVariablePct = taxPct + adv.pctExtra + (profitType === "pct" ? (profitValue / 100) : 0);
+
+  return {
+    mode,
+    cost,
+    taxPct,
+    profitType,
+    profitValue,
+    adv,
+    perMarketplace,
+    totalVariablePct,
+    totalFixed: adv.fixedBRL
+  };
+}
+
+function renderSimulationSummary(context = buildSimulationSummaryContext()) {
+  const root = document.querySelector("#simulationSummaryContent");
+  if (!root) return;
+
+  const profitLine = context.profitType === "pct"
+    ? `Margem alvo: <strong>${Math.max(0, context.profitValue).toFixed(2)}%</strong> sobre o preço de venda`
+    : `Lucro alvo: <strong>${brl(context.profitValue)}</strong> por pedido`;
+
+  const marketplaceRows = context.perMarketplace.length
+    ? context.perMarketplace.map((item) => `<li><span>${item.label}</span><strong>${item.disabled ? "inativo" : formatPct(item.commissionPct)}</strong></li>`).join("")
+    : '<li><span>Nenhum marketplace selecionado</span><strong>—</strong></li>';
+
+  const affiliateRows = context.perMarketplace.length
+    ? context.perMarketplace.map((item) => `<li><span>${item.label}</span><strong>${item.disabled ? "inativo" : formatPct(item.affiliatePct)}</strong></li>`).join("")
+    : "";
+
+  root.innerHTML = `
+    <div class="simulationSummaryGrid">
+      <article class="summaryCard">
+        <h4>O que está ativo</h4>
+        <ul>
+          <li><span>Custo base do produto</span><strong>${brl(context.cost)}</strong></li>
+          <li><span>Imposto de venda</span><strong>${formatPct(context.taxPct)}</strong></li>
+          <li><span>${profitLine}</span></li>
+          <li><span>Custos fixos extras</span><strong>${brl(context.totalFixed)}</strong></li>
+          <li><span>Total incidências variáveis (sem comissão do canal)</span><strong>${formatPct(context.totalVariablePct)}</strong></li>
+        </ul>
+      </article>
+      <article class="summaryCard">
+        <h4>Comissão por canal</h4>
+        <ul>${marketplaceRows}</ul>
+      </article>
+      <article class="summaryCard">
+        <h4>Afiliados por canal</h4>
+        <ul>${affiliateRows}</ul>
+      </article>
+      <article class="summaryCard">
+        <h4>Ordem lógica aplicada</h4>
+        <ol>
+          <li>Somamos custo do produto + custos fixos por pedido.</li>
+          <li>Aplicamos comissões e incidências percentuais sobre o preço de venda.</li>
+          <li>Garantimos a meta de lucro/margem informada.</li>
+          <li>Resolvemos o preço sugerido por marketplace.</li>
+        </ol>
+      </article>
+    </div>
+  `;
+}
+
+function renderResultTransparencySummary(context = LAST_CALC_CONTEXT) {
+  const root = document.querySelector("#resultTransparencySummary");
+  if (!root || !context) return;
+
+  const lines = (context.computedResults || [])
+    .filter((item) => Number.isFinite(item.price))
+    .sort((a, b) => a.price - b.price)
+    .map((item) => `<li><span>${item.title}</span><strong>${brl(item.price)}</strong></li>`)
+    .join("");
+
+  root.innerHTML = `
+    <div class="summaryCallout">
+      <strong>Como chegar no preço final:</strong>
+      custo base ${brl(context.cost)} + custos fixos ${brl(context.adv.fixedBRL)} + incidências percentuais (imposto e taxas) + margem alvo.
+    </div>
+    <div class="resultSummaryGrid">
+      <div>
+        <h4>Totais usados na simulação</h4>
+        <ul>
+          <li><span>Custos fixos por pedido</span><strong>${brl(context.adv.fixedBRL)}</strong></li>
+          <li><span>Incidências extras (%)</span><strong>${formatPct(context.adv.pctExtra)}</strong></li>
+          <li><span>Imposto de venda (%)</span><strong>${formatPct(context.taxPct / 100)}</strong></li>
+        </ul>
+      </div>
+      <div>
+        <h4>Preço final recomendado</h4>
+        <ul>${lines || '<li><span>Sem resultado disponível</span><strong>—</strong></li>'}</ul>
+      </div>
+    </div>
+  `;
 }
 
 function validateStep(step) {
@@ -2980,8 +3121,13 @@ function renderWizardUI() {
 
   toggleUxModeSections();
 
+  if (wizardStep === 3) {
+    renderSimulationSummary(buildSimulationSummaryContext());
+  }
+
   if (wizardStep === 4) {
     applyWizardResultFilter();
+    renderResultTransparencySummary(LAST_CALC_CONTEXT);
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -637,6 +637,14 @@
             <p>Regra: custos fixos e lucro em R$ somam no custo. Depois, somamos incidências em % (comissão + imposto [+ lucro% se escolhido] + custos%) e calculamos: <strong>Preço = custo ajustado ÷ (1 − incidências)</strong>.</p>
           </details>
 
+          <section class="formBlock wizardStep is-hidden simulationSummary" data-step="3" id="simulationSummaryBlock" aria-live="polite">
+            <div class="formBlock__head">
+              <h3>Resumo da simulação</h3>
+              <p>Antes de calcular, confira o que está ativo e em qual ordem entra no preço sugerido.</p>
+            </div>
+            <div id="simulationSummaryContent"></div>
+          </section>
+
           <div class="formDivider wizardStep is-hidden" data-step="3"></div>
 
           <section class="formBlock formBlock--actions wizardStep is-hidden" data-step="3">
@@ -659,6 +667,7 @@
               <h3>Resultado</h3>
               <p>Confira o resultado por marketplace selecionado.</p>
             </div>
+            <div id="resultTransparencySummary" class="resultTransparencySummary" aria-live="polite"></div>
             <div class="actions wizardActions">
               <button id="wizardEditData" class="btn btn--ghost" type="button">Editar dados</button>
               <button id="wizardNewCalc" class="btn btn--primary" type="button">Novo cálculo</button>


### PR DESCRIPTION
### Motivation
- Reduce the “caixa preta” feeling in the final step by summarizing what will be used in the calculation and showing the breakdown after calculation. 
- Make it explicit which marketplaces, commissions and extra costs are active so users can trust the suggested price. 
- Show the logical order of the calculation and the per-marketplace recommended prices for easier auditing and decision-making.

### Description
- Added a new pre-calc block in the wizard (`#simulationSummaryBlock`) that summarizes active items (cost base, tax, profit mode/value, fixed extras, total variable incidences), commissions per channel and affiliate rates. (`index.html`, `assets/js/main.js`).
- Added a result transparency panel (`#resultTransparencySummary`) on the results step that explains the final formula, lists totals used (fixed and percent), and displays recommended prices per marketplace. (`index.html`, `assets/js/main.js`).
- Implemented JS helpers `buildSimulationSummaryContext`, `renderSimulationSummary`, `renderResultTransparencySummary` and a `LAST_CALC_CONTEXT` variable to assemble and render dynamic summaries during wizard navigation and after `recalc` runs, and hooked rendering into `recalc` and `renderWizardUI` flows. (`assets/js/main.js`).
- Added supporting CSS for summary cards and responsive grid layout. (`assets/css/styles.css`).

### Testing
- Static syntax check: ran `node --check assets/js/main.js` and it succeeded. 
- Local server smoke: served the app with `python -m http.server 4173` and exercised the wizard flow programmatically (navigation + inputs) to validate DOM integration; summary and result rendering functions were executed in the page context. 
- Browser automation attempt with Playwright to capture screenshots failed due to a Chromium crash in the execution environment (Playwright/Chromium SIGSEGV), so no automated visual screenshots were produced in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8687427a48332b6c9430bfb47615d)