### PR TITLE
Manter seção 'Custos Extras' visível e travada no passo final da precificação

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1852,7 +1852,16 @@ body.theme-dark .wizardStepper__label{color:rgba(148,163,184,.7)}
   overflow:hidden;
   transition:max-height .3s ease;
 }
-.adjCard.is-open .adjCard__body{max-height:1400px}
+.adjCard.is-open .adjCard__body,
+.adjCard.is-locked-open .adjCard__body{max-height:1400px}
+
+.adjCard.is-locked-open .adjCard__header{
+  cursor:default;
+}
+
+.adjCard.is-locked-open .adjCard__chevron{
+  opacity:.35;
+}
 
 .adjCard__inner{
   padding:0 14px 14px;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2618,6 +2618,23 @@ function bindAdjCards() {
   });
 }
 
+function syncExtraCostsCardVisibility() {
+  const extraCostsCard = document.querySelector("#adjCard-custos");
+  const trigger = extraCostsCard?.querySelector(".adjCard__header");
+  if (!extraCostsCard || !trigger) return;
+
+  const lockOpen = wizardStep === 3;
+
+  extraCostsCard.classList.toggle("is-locked-open", lockOpen);
+  trigger.disabled = lockOpen;
+  trigger.setAttribute("aria-disabled", String(lockOpen));
+
+  if (lockOpen) {
+    extraCostsCard.classList.add("is-open");
+    trigger.setAttribute("aria-expanded", "true");
+  }
+}
+
 
 function getTriggerSelector(trigger) {
   return trigger?.getAttribute("data-target")
@@ -3120,6 +3137,7 @@ function renderWizardUI() {
   });
 
   toggleUxModeSections();
+  syncExtraCostsCardVisibility();
 
   if (wizardStep === 3) {
     renderSimulationSummary(buildSimulationSummaryContext());


### PR DESCRIPTION
### Motivation
- Garantir que a seção "Custos Extras" fique sempre aparente na etapa final do wizard para melhorar a leitura antes do cálculo. 
- Evitar que o usuário precise expandir manualmente o bloco quando estiver revisando ajustes finais. 
- Manter inalterada a lógica financeira, alterando apenas comportamento visual e de interação.

### Description
- Adiciona a função `syncExtraCostsCardVisibility()` em `assets/js/main.js` que aplica/remove a classe `is-locked-open`, marca o botão do cabeçalho como `disabled` e atualiza `aria-disabled`/`aria-expanded` quando `wizardStep === 3`.
- Integra a sincronização ao fluxo de UI chamando `syncExtraCostsCardVisibility()` dentro de `renderWizardUI()` para aplicar o estado ao entrar/sair da etapa final.
- Atualiza `assets/css/styles.css` com regras para `.adjCard.is-locked-open` mantendo o corpo expandido e ajustando estilo do cabeçalho e do chevron para indicar bloqueio.
- Arquivos alterados: `assets/js/main.js` e `assets/css/styles.css`.

### Testing
- Executado `node --check assets/js/main.js` para checar sintaxe do bundle JavaScript (sucesso).
- Levantado servidor estático com `python3 -m http.server 4173 --bind 0.0.0.0` e verificada a página no navegador (sucesso).
- Automatizada a navegação até a etapa final com Playwright e gerada captura de tela para validar que `#adjCard-custos` ficou com `is-locked-open` visível (captura gerada com sucesso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b86c26d85883329d21ba85fea267ae)