### PR TITLE
Pré-seleciona todos marketplaces no passo 'Dados' e integra 'Margem' na mesma seção

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2760,7 +2760,7 @@ const MARKETPLACE_TITLE_TO_KEY = {
   "Amazon (DBA)": "amazon"
 };
 
-let UX_SELECTED_MARKETPLACES = ["amazon"];
+let UX_SELECTED_MARKETPLACES = UX_MARKETPLACES.map((mp) => mp.key);
 const UX_PRICE_VALUES = {};
 let UX_RECALC_TIMER = null;
 let wizardStep = 0;

--- a/index.html
+++ b/index.html
@@ -270,7 +270,7 @@
           <section class="formBlock wizardStep is-hidden" data-step="1">
             <div class="formBlock__head">
               <h3>Dados do cálculo</h3>
-              <p>Selecione os marketplaces e preencha os dados do produto.</p>
+              <p>Selecione os marketplaces e preencha os dados do produto, margem e ajustes.</p>
             </div>
 
             <!-- Marketplace selector -->
@@ -327,10 +327,9 @@
                 </div>
               </div>
             </div>
-          </section>
 
-          <!-- Profit goal -->
-          <section class="formBlock wizardStep is-hidden" data-step="1" id="profitGoalSection">
+            <!-- Profit goal -->
+            <div class="formBlock" id="profitGoalSection">
             <div class="formBlock__head">
               <h3 id="profitGoalHeading">Margem desejada</h3>
               <p>Defina sua margem em valor fixo ou em percentual.</p>
@@ -370,6 +369,8 @@
             </div>
 
             <input id="profitValue" class="is-hidden" type="number" step="0.01" min="0" value="10" tabindex="-1" aria-hidden="true" />
+          </div>
+
           </section>
 
           <!-- Personalizar comissão marketplace -->


### PR DESCRIPTION
### Motivation
- Tornar o passo 2 (Dados) mais imediato ao pré-selecionar todos os marketplaces em vez de apenas a Amazon. 
- Agrupar margem desejada, custos extras e afiliados na mesma hierarquia/fluxo dos campos de custo, imposto e peso para melhorar a usabilidade e corresponder à solicitação de organizar tudo no mesmo passo.

### Description
- Inicializa `UX_SELECTED_MARKETPLACES` com todas as chaves de `UX_MARKETPLACES` em `assets/js/main.js` (`let UX_SELECTED_MARKETPLACES = UX_MARKETPLACES.map((mp) => mp.key);`).
- Atualiza a microcopy do bloco `Dados do cálculo` em `index.html` para refletir que produto, margem e ajustes estão no mesmo passo. 
- Reorganiza a estrutura HTML movendo/embutindo o bloco `Margem desejada` dentro do mesmo `formBlock` de "Dados do cálculo" em `index.html` para manter a hierarquia solicitada.
- Arquivos alterados: `assets/js/main.js`, `index.html`.

### Testing
- Verificação de sintaxe JavaScript com `node --check assets/js/main.js` (sucesso).
- Verificação de sintaxe HTML/PHP com `php -l index.html` (sucesso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c34e82ec5083329216da2f385ac90d)