### PR TITLE
Refactor pricing calculator to single-screen flat layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -716,6 +716,55 @@ body.theme-dark .leadCapture__head p{color:#94a3b8}
   .marketplaceChip{min-height:72px}
 }
 
+/* ===== Price or Margin row ===== */
+.row3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:12px;align-items:end}
+.priceOrMarginRow{
+  display:grid;
+  grid-template-columns:1fr auto 1fr;
+  gap:20px;
+  align-items:start;
+  margin:16px 0;
+  padding:18px;
+  border:1.5px solid color-mix(in srgb,var(--accent) 28%,var(--stroke) 72%);
+  border-radius:16px;
+  background:linear-gradient(180deg,color-mix(in srgb,var(--accent-soft) 55%,#fff),#fff 80%);
+}
+.priceOrMargin__side{display:flex;flex-direction:column;gap:8px}
+.priceOrMargin__side .formBlock__head{margin-bottom:0}
+.priceOrMargin__side .formBlock__head h3{font-size:15px;margin:0}
+.priceOrMargin__side .formBlock__head p{margin:3px 0 0;font-size:12px;color:var(--muted);line-height:1.4}
+.priceOrMargin__or{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding-top:36px;
+}
+.priceOrMargin__or span{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:34px;
+  height:34px;
+  border-radius:999px;
+  border:1px solid var(--stroke);
+  background:#fff;
+  font-size:11px;
+  font-weight:800;
+  color:var(--muted);
+  text-transform:uppercase;
+  letter-spacing:.04em;
+  flex-shrink:0;
+}
+@media(max-width:768px){
+  .row3{grid-template-columns:1fr 1fr}
+  .priceOrMarginRow{grid-template-columns:1fr;gap:14px}
+  .priceOrMargin__or{padding-top:0;justify-content:flex-start}
+  .priceOrMargin__or span{width:28px;height:28px;font-size:10px}
+}
+@media(max-width:480px){
+  .row3{grid-template-columns:1fr}
+}
+
 /* ===== Premium WOW Refresh (visual only) ===== */
 :root{
   --bg:#edf2ff;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1885,20 +1885,19 @@ function renderCurrentPriceAnalysis(state) {
     return;
   }
 
-  const hasAnyPrice = activeMPs.some((mp) => String(UX_PRICE_VALUES[mp.key] || "").trim() !== "");
+  const price = Math.max(0, toNumber(document.querySelector("#salePrice")?.value));
 
-  if (!hasAnyPrice) {
+  if (!price) {
     resultsEl.innerHTML = `
       <div class="hint" style="padding:1.25rem;text-align:center;line-height:1.6;">
-        <strong>Preencha os preços de venda</strong><br>
-        <small>Volte ao passo anterior e informe o valor cobrado em cada marketplace para ver seu lucro real.</small>
+        <strong>Preencha o preço de venda</strong><br>
+        <small>Informe o valor que você cobra para ver seu lucro real por marketplace.</small>
       </div>
     `;
     return;
   }
 
   const cards = activeMPs.map((mp) => {
-    const price = getCurrentPriceForMarketplace(mp.key);
     const analysis = calculateMarketplaceAtPrice({
       price,
       cost: state.cost,
@@ -1913,7 +1912,7 @@ function renderCurrentPriceAnalysis(state) {
   });
 
   resultsEl.innerHTML = cards.join("");
-  trackGA4Event("current_profit_calculate", { mode: "per_marketplace" });
+  trackGA4Event("current_profit_calculate", { mode: "global_price" });
 }
 
 function renderScaleSimulation(state) {
@@ -2767,7 +2766,8 @@ let wizardStep = 0;
 let LAST_CALC_CONTEXT = null;
 
 function getCalcMode() {
-  return document.querySelector('input[name="calcMode"]:checked')?.value || "";
+  const salePrice = toNumber(document.querySelector("#salePrice")?.value);
+  return salePrice > 0 ? "real" : "ideal";
 }
 
 function getSelectedMarketplaces() {
@@ -2833,30 +2833,8 @@ function renderMode1PriceInputs() {
 }
 
 function toggleUxModeSections() {
-  const mode = getCalcMode();
-  const hasMode = Boolean(mode);
-  const mode1PriceSection = document.querySelector("#mode1PriceSection");
-  const profitGoalSection = document.querySelector("#profitGoalSection");
-  const hint = document.querySelector("#calcModeMicrocopy");
-
-  if (!hasMode) {
-    mode1PriceSection?.classList.add("is-hidden");
-    profitGoalSection?.classList.add("is-hidden");
-    if (hint) hint.textContent = "";
-    return;
-  }
-
-  const isStep1 = wizardStep === 1;
-  mode1PriceSection?.classList.toggle("is-hidden", !(mode === "real" && isStep1));
-  profitGoalSection?.classList.toggle("is-hidden", !(mode === "ideal" && isStep1));
-  const heading = document.querySelector("#profitGoalHeading");
-  if (heading) heading.textContent = "Margem desejada";
-
-  if (hint) {
-    hint.textContent = mode === "real"
-      ? "Preço pode variar por marketplace. Preencha o valor correspondente a cada canal."
-      : "Vamos calcular o preço ideal por marketplace com base na margem informada.";
-  }
+  // In the flat single-screen layout, all sections are always visible.
+  // No toggling needed.
 }
 
 function formatPct(value) {
@@ -2987,113 +2965,22 @@ function renderResultTransparencySummary(context = LAST_CALC_CONTEXT) {
   `;
 }
 
-function validateStep(step) {
-  if (step === 1) {
-    return getSelectedMarketplaces().length > 0 && Boolean(getCalcMode());
-  }
-  return true;
-}
-
-
-function updateWizardSummary() {
-  const summary = document.querySelector(".wizardSummary");
-  if (!summary) return;
-
-  const estimatedTime = document.querySelector("#wizardSummaryTime");
-  if (estimatedTime) {
-    estimatedTime.textContent = `Tempo estimado: 3 min`;
-  }
-
-  const items = summary.querySelectorAll(".wizardSummary__list li");
-  items.forEach((item, index) => {
-    item.classList.toggle("is-done", wizardStep > index);
-    item.classList.toggle("is-current", wizardStep === index);
-  });
-}
-
+function validateStep() { return true; }
+function updateWizardSummary() {}
 function applyWizardResultFilter() {
   const selected = new Set(getSelectedMarketplaces());
   document.querySelectorAll("#results .marketplaceCard").forEach((card) => {
     const title = card.querySelector(".cardTitle")?.textContent?.trim() || "";
     const key = MARKETPLACE_TITLE_TO_KEY[title];
-    if (!key) {
-      card.classList.remove("is-hidden");
-      return;
-    }
+    if (!key) { card.classList.remove("is-hidden"); return; }
     card.classList.toggle("is-hidden", !selected.has(key));
   });
 }
-
-function updateStepperDots(step) {
-  // step 0 = objetivo, step 1 = dados, step 4 = resultado (3-item stepper)
-  document.querySelectorAll(".wizardStepper__item").forEach((el) => {
-    const s = parseInt(el.dataset.stepperStep, 10);
-    const isDone = (s === 0 && step >= 1) || (s === 1 && step >= 4);
-    const isActive = (s === 0 && step === 0) || (s === 1 && step === 1) || (s === 2 && step >= 4);
-    el.classList.toggle("is-done", isDone);
-    el.classList.toggle("is-active", isActive);
-  });
-  const fill = document.querySelector("#wizardStepperFill");
-  if (fill) {
-    const pct = step === 0 ? 0 : step === 1 ? 50 : 100;
-    fill.style.width = pct + "%";
-  }
-}
-
-function setWizardStep(step) {
-  wizardStep = clamp(step, 0, 4);
-  renderWizardUI();
-}
-
-function renderWizardUI() {
-  if (!getCalcMode() && wizardStep > 0) {
-    wizardStep = 0;
-  }
-
-  document.querySelectorAll(".wizardStep").forEach((el) => {
-    const step = Number(el.dataset.step || 0);
-    el.classList.toggle("is-hidden", step !== wizardStep);
-  });
-
-  const progress = document.querySelector("#wizardProgress");
-  const visibleStep = wizardStep === 4 ? 2 : Math.min(wizardStep, 2);
-  if (progress) progress.textContent = `Passo ${visibleStep} de 2`;
-
-  updateStepperDots(wizardStep);
-  updateWizardSummary();
-
-  const recalcBtn = document.querySelector("#recalc");
-  if (recalcBtn && wizardStep === 1) recalcBtn.disabled = !validateStep(1);
-
-  const resultsContainer = document.querySelector(".wizardResultsContainer");
-  if (resultsContainer) {
-    resultsContainer.classList.toggle("is-hidden", wizardStep !== 4);
-  }
-
-  const mode = getCalcMode();
-  document.querySelectorAll(".modeCard").forEach((card) => {
-    const isSelected = card.dataset.mode === mode;
-    card.classList.toggle("is-selected", isSelected);
-    card.setAttribute("aria-pressed", String(isSelected));
-  });
-
-  toggleUxModeSections();
-  syncExtraCostsCardVisibility();
-
-  if (wizardStep === 4) {
-    applyWizardResultFilter();
-    renderResultTransparencySummary(LAST_CALC_CONTEXT);
-  }
-}
-
-function handleNext() {
-  if (wizardStep === 1 && !validateStep(1)) return;
-  setWizardStep(wizardStep + 1);
-}
-
-function handleBack() {
-  setWizardStep(wizardStep - 1);
-}
+function updateStepperDots() {}
+function setWizardStep() {}
+function renderWizardUI() {}
+function handleNext() {}
+function handleBack() {}
 
 function uxRecalc() {
   recalc({ source: "auto" });
@@ -3107,109 +2994,40 @@ function debounceUxRecalc() {
 
 function initUxRefactor() {
   buildMarketplaceSelector();
-  renderMode1PriceInputs();
 
+  // Default profit mode to %
   const profitValuePct = document.querySelector("#profitValuePct");
   const metaPercent = document.querySelector("#meta_percent");
   if (profitValuePct && metaPercent) {
     profitValuePct.value = "10";
     metaPercent.checked = true;
-    document.querySelector("#profitType").value = "pct";
-    document.querySelector("#profitValue").value = "10";
+    const profitType = document.querySelector("#profitType");
+    const profitValue = document.querySelector("#profitValue");
+    if (profitType) profitType.value = "pct";
+    if (profitValue) profitValue.value = "10";
     document.querySelector("#profitFieldBRL")?.classList.add("is-hidden");
     document.querySelector("#profitFieldPCT")?.classList.remove("is-hidden");
   }
 
-  const selectCalcMode = (mode) => {
-    if (!mode) return;
-    const real = document.querySelector("#mode_real");
-    const ideal = document.querySelector("#mode_ideal");
-    if (mode === "real" && real) {
-      real.checked = true;
-      real.dispatchEvent(new Event("change", { bubbles: true }));
-    }
-    if (mode === "ideal" && ideal) {
-      ideal.checked = true;
-      ideal.dispatchEvent(new Event("change", { bubbles: true }));
-    }
-    setWizardStep(1);
-  };
-
-  const calcModeCards = document.querySelector("#calcModeCards");
-  const handleCalcModeCardInteraction = (event) => {
-    const card = event.target.closest?.(".modeCard");
-    if (!card) return;
-    selectCalcMode(card.dataset.mode);
-  };
-
-  const handleCalcModeCardKeydown = (event) => {
-    const card = event.target.closest?.(".modeCard");
-    const isActionKey = event.key === "Enter" || event.key === " " || event.code === "Space";
-    if (!card || !isActionKey) return;
-    event.preventDefault();
-    selectCalcMode(card.dataset.mode);
-  };
-
-  calcModeCards?.addEventListener("click", handleCalcModeCardInteraction);
-  calcModeCards?.addEventListener("keydown", handleCalcModeCardKeydown);
-
-  document.querySelector("#mode1PriceInputs")?.addEventListener("input", (event) => {
-    const input = event.target.closest("[data-ux-price-marketplace]");
-    if (!input) return;
-    UX_PRICE_VALUES[input.dataset.uxPriceMarketplace] = input.value;
-    debounceUxRecalc();
-  });
-
   document.querySelector("#marketplaceSelector")?.addEventListener("change", () => {
     UX_SELECTED_MARKETPLACES = UX_MARKETPLACES.map((mp) => mp.key).filter((key) => document.querySelector(`#ux_mp_${key}`)?.checked);
-    renderMode1PriceInputs();
-    renderWizardUI();
     uxRecalc();
   });
 
-  document.querySelectorAll('input[name="calcMode"]').forEach((el) => el.addEventListener("change", () => {
-    if (wizardStep === 0 && getCalcMode()) {
-      setWizardStep(1);
-      return;
-    }
-    toggleUxModeSections();
-    renderWizardUI();
-  }));
-
-  ["#cost", "#tax", "#globalWeightInput", "#profitValueBRL", "#profitValuePct"].forEach((selector) => {
+  ["#cost", "#tax", "#globalWeightInput", "#profitValueBRL", "#profitValuePct", "#salePrice"].forEach((selector) => {
     document.querySelector(selector)?.addEventListener("input", debounceUxRecalc);
   });
   document.querySelector("#globalWeightUnit")?.addEventListener("change", uxRecalc);
-
-  document.querySelector("#wizardBackStep1")?.addEventListener("click", handleBack);
-  document.querySelector("#wizardEditData")?.addEventListener("click", () => setWizardStep(1));
-  document.querySelector("#wizardNewCalc")?.addEventListener("click", () => {
-    document.querySelectorAll('input[name="calcMode"]').forEach((el) => {
-      el.checked = false;
-    });
-    setWizardStep(0);
-  });
-
 
   document.querySelector("#recalc")?.addEventListener("click", (event) => {
     event.preventDefault();
     event.stopImmediatePropagation();
     recalc({ source: "manual" });
-    applyWizardResultFilter();
-    setWizardStep(4);
-  });
-
-  document.querySelectorAll('input[name="calcMode"]').forEach((el) => {
-    el.checked = false;
+    const results = document.querySelector("#results");
+    scrollToWithTopbarOffset(results);
   });
 
   uxRecalc();
-  setWizardStep(0);
-  renderWizardUI();
-  window.setTimeout(() => {
-    setWizardStep(0);
-    renderWizardUI();
-  }, 0);
 }
 
 function initApp() {

--- a/index.html
+++ b/index.html
@@ -166,285 +166,172 @@
 
     <section id="sec-precificacao" class="sectionCard">
       <h2>Precificação</h2>
-      <p class="sectionMicrocopy">Preencha os dados principais para descobrir o preço ideal com lucro real.</p>
+      <p class="sectionMicrocopy">Preencha os custos, selecione os marketplaces e informe o preço de venda ou a margem desejada.</p>
       <div class="grid">
       <div class="card pricingCard">
         <div class="card__inner">
-          <!-- Progress stepper -->
-          <div class="wizardStepper" id="wizardStepper" aria-label="Progresso do formulário">
-            <div class="wizardStepper__track" aria-hidden="true">
-              <div class="wizardStepper__fill" id="wizardStepperFill"></div>
-            </div>
-            <div class="wizardStepper__items" aria-hidden="true">
-              <div class="wizardStepper__item" data-stepper-step="0">
-                <div class="wizardStepper__dot">
-                  <svg class="wizardStepper__check" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M2 6.5l2.8 2.8 5-5.6"/></svg>
-                </div>
-                <span class="wizardStepper__label">Objetivo</span>
-              </div>
-              <div class="wizardStepper__item" data-stepper-step="1">
-                <div class="wizardStepper__dot">
-                  <svg class="wizardStepper__check" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M2 6.5l2.8 2.8 5-5.6"/></svg>
-                </div>
-                <span class="wizardStepper__label">Dados</span>
-              </div>
-              <div class="wizardStepper__item" data-stepper-step="2">
-                <div class="wizardStepper__dot">
-                  <svg class="wizardStepper__check" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M2 6.5l2.8 2.8 5-5.6"/></svg>
-                </div>
-                <span class="wizardStepper__label">Resultado</span>
-              </div>
-            </div>
+          <!-- ── Marketplace selector ── -->
+          <div class="field">
+            <div class="label">Marketplaces</div>
+            <div id="marketplaceSelector" class="marketplaceSelector" aria-label="Selecionar marketplaces"></div>
           </div>
-          <!-- Hidden live region for a11y -->
-          <div id="wizardProgress" class="sr-only" aria-live="polite">Passo 0 de 4</div>
 
-          <section class="formBlock wizardStep" data-step="0">
-            <div class="formBlock__head">
-              <h3>O que você precisa saber hoje?</h3>
+          <!-- ── Nome do cálculo ── -->
+          <div class="field">
+            <div class="label label-row">
+              <span>Nome do cálculo / produto</span>
+              <button class="info" type="button" aria-label="Info: Nome do cálculo / produto" data-tooltip="Dê um nome para identificar este cálculo no PDF e no salvamento local. Ex: Camiseta Dry Fit Preta.">i</button>
             </div>
-            <p class="modeInstruction" id="calcModeInstruction">Escolha um modo para continuar</p>
+            <input id="calcName" type="text" maxlength="80" placeholder="Ex: Camiseta Dry Fit Preta" />
+          </div>
 
-            <div class="wizardSummary" aria-live="polite">
-              <div class="wizardSummary__head">
-                <h4>Mapa do escopo</h4>
-                <p id="wizardSummaryTime">Tempo estimado: 0 min</p>
-              </div>
-              <ul class="wizardSummary__list" id="wizardSummaryList">
-                <li>
-                  <span>Etapa 1 · Escolha do objetivo</span>
-                  <span class="wizardSummary__badge wizardSummary__badge--required">Obrigatório</span>
-                </li>
-                <li>
-                  <span>Etapa 2 · Dados e marketplaces</span>
-                  <span class="wizardSummary__badge wizardSummary__badge--required">Obrigatório</span>
-                </li>
-              </ul>
-            </div>
-
-            <div id="calcModeCards" class="modeCards" role="group" aria-label="Escolher modo de cálculo" aria-describedby="calcModeInstruction">
-              <button class="modeCard modeCard--teal" type="button" data-mode="real" aria-pressed="false">
-                <span class="modeCard__check" aria-hidden="true">
-                  <svg viewBox="0 0 20 20" focusable="false" aria-hidden="true">
-                    <path d="M7.7 14.2 3.8 10.3a1 1 0 1 1 1.4-1.4l2.5 2.5 7.1-7.1a1 1 0 0 1 1.4 1.4l-8.5 8.5a1 1 0 0 1-1.4 0Z"></path>
-                  </svg>
-                </span>
-                <span class="modeCard__icon modeCard__icon--teal" aria-hidden="true">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" focusable="false" aria-hidden="true">
-                    <line x1="12" y1="20" x2="12" y2="10"/><line x1="18" y1="20" x2="18" y2="4"/><line x1="6" y1="20" x2="6" y2="16"/>
-                    <path d="M2 20h20"/>
-                  </svg>
-                </span>
-                <strong>Quanto estou ganhando de verdade?</strong>
-                <p>Coloque o preço que você já pratica e descubra seu lucro real — após comissão, taxas e custos do marketplace.</p>
-              </button>
-              <button class="modeCard modeCard--blue" type="button" data-mode="ideal" aria-pressed="false">
-                <span class="modeCard__check" aria-hidden="true">
-                  <svg viewBox="0 0 20 20" focusable="false" aria-hidden="true">
-                    <path d="M7.7 14.2 3.8 10.3a1 1 0 1 1 1.4-1.4l2.5 2.5 7.1-7.1a1 1 0 0 1 1.4 1.4l-8.5 8.5a1 1 0 0 1-1.4 0Z"></path>
-                  </svg>
-                </span>
-                <span class="modeCard__icon modeCard__icon--blue" aria-hidden="true">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" focusable="false" aria-hidden="true">
-                    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Z"/>
-                    <path d="M12 6v6l4 2"/>
-                  </svg>
-                </span>
-                <strong>Por quanto devo vender?</strong>
-                <p>Informe seu custo e a margem que quer ter. O sistema calcula o preço certo para cada marketplace.</p>
-              </button>
-                </div>
-              </div>
-            </div>
-
-            <div class="field is-hidden" id="calcModeField">
-              <div class="segmented segmented--goal" role="radiogroup" aria-label="Modo de cálculo">
-                <input id="mode_real" type="radio" name="calcMode" value="real" />
-                <label for="mode_real">Lucro real</label>
-                <input id="mode_ideal" type="radio" name="calcMode" value="ideal" />
-                <label for="mode_ideal">Preço ideal</label>
-              </div>
-            </div>
-          </section>
-
-          <section class="formBlock wizardStep is-hidden" data-step="1">
-            <div class="formBlock__head">
-              <h3>Dados do cálculo</h3>
-              <p>Selecione os marketplaces e preencha os dados do produto, margem e ajustes.</p>
-            </div>
-
-            <!-- Marketplace selector -->
-            <div class="field">
-              <div class="label">Marketplaces</div>
-              <div id="marketplaceSelector" class="marketplaceSelector" aria-label="Selecionar marketplaces"></div>
-            </div>
-
-            <!-- Product data -->
+          <!-- ── Custo + Imposto + Peso ── -->
+          <div class="formRow row3">
             <div class="field">
               <div class="label label-row">
-                <span>Nome do cálculo / produto</span>
-                <button class="info" type="button" aria-label="Info: Nome do cálculo / produto" data-tooltip="Dê um nome para identificar este cálculo no PDF e no salvamento local. Ex: Camiseta Dry Fit Preta.">i</button>
+                <span>Custo total (R$)</span>
+                <button class="info" type="button" aria-label="Info: Custo total (R$)" data-tooltip="O custo total do produto antes da venda: compra + impostos/encargos de compra. Ex: preço do fornecedor + ICMS-ST (se houver) + frete de compra, se você já embute no custo.">i</button>
               </div>
-              <input id="calcName" type="text" maxlength="80" placeholder="Ex: Camiseta Dry Fit Preta" />
-            </div>
-
-            <div class="formRow row2">
-              <div class="field">
-                <div class="label label-row">
-                  <span>Custo total (R$)</span>
-                  <button class="info" type="button" aria-label="Info: Custo total (R$)" data-tooltip="O custo total do produto antes da venda: compra + impostos/encargos de compra. Ex: preço do fornecedor + ICMS-ST (se houver) + frete de compra, se você já embute no custo.">i</button>
-                </div>
-                <div class="inputWrap">
-                  <span class="inputPrefix">R$</span>
-                  <input id="cost" type="number" step="0.01" min="0" value="60" />
-                </div>
-              </div>
-
-              <div class="field">
-                <div class="label label-row">
-                  <span>Imposto de venda (%)</span>
-                  <button class="info" type="button" aria-label="Info: Imposto de venda (%)" data-tooltip="Percentual de imposto que incide na venda (sobre o preço de venda). Use a alíquota efetiva do seu cenário.">i</button>
-                </div>
-                <div class="inputWrap">
-                  <input id="tax" type="number" step="0.01" min="0" value="10" />
-                  <span class="inputSuffix">%</span>
-                </div>
-              </div>
-
-              <div class="field">
-                <div class="label label-row">
-                  <span>Peso (opcional)</span>
-                  <button class="info" type="button" aria-label="Info: Peso (opcional)" data-tooltip="Peso global usado nas regras dos marketplaces que dependem de peso. Se não informar, o sistema mantém o padrão atual de 0,5 kg.">i</button>
-                </div>
-                <div class="formRow row2">
-                  <div class="inputWrap">
-                    <input id="globalWeightInput" type="number" step="0.001" min="0" placeholder="Ex: 0.5" />
-                  </div>
-                  <select id="globalWeightUnit" aria-label="Unidade do peso global">
-                    <option value="kg" selected>kg</option>
-                    <option value="g">g</option>
-                  </select>
-                </div>
-              </div>
-            </div>
-
-            <!-- Profit goal -->
-            <div class="formBlock" id="profitGoalSection">
-            <div class="formBlock__head">
-              <h3 id="profitGoalHeading">Margem desejada</h3>
-              <p>Defina sua margem em valor fixo ou em percentual.</p>
-            </div>
-
-            <div class="field">
-              <div class="label label-row">
-                <span>Modo da meta</span>
-                <button class="info" type="button" aria-label="Info: Modo da meta" data-tooltip="Escolha se o lucro desejado será um valor fixo em reais (R$) ou uma margem em % sobre o preço de venda.">i</button>
-              </div>
-              <div class="segmented segmented--goal" role="radiogroup" aria-label="Modo da meta">
-                <input id="meta_reais" type="radio" name="profitMode" value="brl" checked />
-                <label for="meta_reais">Em R$</label>
-                <input id="meta_percent" type="radio" name="profitMode" value="pct" />
-                <label for="meta_percent">Em %</label>
-              </div>
-              <select id="profitType" class="is-hidden" aria-hidden="true" tabindex="-1">
-                <option value="brl" selected>Em R$ (lucro em reais)</option>
-                <option value="pct">Em % (margem sobre o preço)</option>
-              </select>
-            </div>
-
-            <div id="profitFieldBRL" class="field">
-              <div class="label">Lucro desejado (R$)</div>
               <div class="inputWrap">
                 <span class="inputPrefix">R$</span>
-                <input id="profitValueBRL" type="number" step="0.01" min="0" value="10" />
+                <input id="cost" type="number" step="0.01" min="0" value="60" />
               </div>
             </div>
-
-            <div id="profitFieldPCT" class="field is-hidden">
-              <div class="label">Lucro desejado (%)</div>
+            <div class="field">
+              <div class="label label-row">
+                <span>Imposto de venda (%)</span>
+                <button class="info" type="button" aria-label="Info: Imposto de venda (%)" data-tooltip="Percentual de imposto que incide na venda (sobre o preço de venda). Use a alíquota efetiva do seu cenário.">i</button>
+              </div>
               <div class="inputWrap">
-                <input id="profitValuePct" type="number" step="0.01" min="0" value="10" />
+                <input id="tax" type="number" step="0.01" min="0" value="10" />
                 <span class="inputSuffix">%</span>
               </div>
             </div>
-
-            <input id="profitValue" class="is-hidden" type="number" step="0.01" min="0" value="10" tabindex="-1" aria-hidden="true" />
+            <div class="field">
+              <div class="label label-row">
+                <span>Peso (opcional)</span>
+                <button class="info" type="button" aria-label="Info: Peso (opcional)" data-tooltip="Peso global usado nas regras dos marketplaces que dependem de peso. Se não informar, o sistema mantém o padrão de 0,5 kg.">i</button>
+              </div>
+              <div class="formRow row2">
+                <div class="inputWrap">
+                  <input id="globalWeightInput" type="number" step="0.001" min="0" placeholder="Ex: 0.5" />
+                </div>
+                <select id="globalWeightUnit" aria-label="Unidade do peso global">
+                  <option value="kg" selected>kg</option>
+                  <option value="g">g</option>
+                </select>
+              </div>
+            </div>
           </div>
 
-          </section>
-
-          <!-- Personalizar comissão marketplace -->
-          <section class="formBlock wizardStep is-hidden" data-step="1">
-            <div class="adjRow">
-              <div class="adjRow__icon">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>
+          <!-- ── PREÇO DE VENDA  OU  MARGEM DESEJADA ── -->
+          <div class="priceOrMarginRow">
+            <div class="priceOrMargin__side">
+              <div class="formBlock__head">
+                <h3>Preço de Venda</h3>
+                <p>Você já tem um preço definido? Informe aqui para ver quanto está ganhando em cada canal.</p>
               </div>
-              <label class="check adjRow__label">
-                <input id="customCommissionToggle" type="checkbox" />
-                <span>Personalizar comissão marketplace</span>
-              </label>
-            </div>
-            <div id="customCommissionBox" class="cardMini optionalInlineBox is-hidden">
-              <div class="advGrid">
-                <div class="field">
-                  <div class="label label-row">
-                    <span>Amazon (%)</span>
-                    <button class="info" type="button" aria-label="Info: Comissão Amazon (%)" data-tooltip="Comissão padrão da Amazon é 15%. Ajuste conforme sua categoria.">i</button>
-                  </div>
-                  <div class="inputWrap">
-                    <input id="amazonPct" type="number" step="0.01" min="0" value="15" />
-                    <span class="inputSuffix">%</span>
-                  </div>
-                </div>
-                <div class="field">
-                  <div class="label label-row">
-                    <span>ML Premium (%)</span>
-                    <button class="info" type="button" aria-label="Info: Mercado Livre Premium (%)" data-tooltip="Comissão padrão ML Premium é 19%. Ajuste conforme sua categoria/anúncio.">i</button>
-                  </div>
-                  <div class="inputWrap">
-                    <input id="mlPremiumPct" type="number" step="0.01" min="0" value="19" />
-                    <span class="inputSuffix">%</span>
-                  </div>
-                </div>
-                <div class="field">
-                  <div class="label label-row">
-                    <span>ML Clássico (%)</span>
-                    <button class="info" type="button" aria-label="Info: Mercado Livre Clássico (%)" data-tooltip="Comissão padrão ML Clássico é 14%. Ajuste conforme sua categoria/anúncio.">i</button>
-                  </div>
-                  <div class="inputWrap">
-                    <input id="mlClassicPct" type="number" step="0.01" min="0" value="14" />
-                    <span class="inputSuffix">%</span>
-                  </div>
-                </div>
-                <div class="field">
-                  <div class="label label-row">
-                    <span>SHEIN (%)</span>
-                    <button class="info" type="button" aria-label="Info: Comissão SHEIN (%)" data-tooltip="Comissão padrão SHEIN: 18% (demais) ou 20% (vestuário feminino). Ajuste conforme sua categoria.">i</button>
-                  </div>
-                  <div class="inputWrap">
-                    <input id="sheinPct" type="number" step="0.01" min="0" value="18" />
-                    <span class="inputSuffix">%</span>
-                  </div>
-                </div>
+              <div class="inputWrap">
+                <span class="inputPrefix">R$</span>
+                <input id="salePrice" type="number" step="0.01" min="0" placeholder="Ex: 99,90" />
               </div>
             </div>
-          </section>
 
-          <!-- Price inputs for "real" mode -->
-          <section class="formBlock wizardStep is-hidden" data-step="1" id="mode1PriceSection">
-            <div class="formBlock__head">
-              <h3>Preço de venda por marketplace</h3>
-              <p id="calcModeMicrocopy">Preço pode variar por marketplace. Preencha o valor correspondente a cada canal.</p>
+            <div class="priceOrMargin__or" aria-hidden="true"><span>ou</span></div>
+
+            <div class="priceOrMargin__side">
+              <div class="formBlock__head">
+                <h3>Margem desejada</h3>
+                <p>Informe quanto quer ganhar e o sistema calcula o preço ideal por marketplace.</p>
+              </div>
+              <div class="segmented segmented--goal" role="radiogroup" aria-label="Modo da meta">
+                <input id="meta_reais" type="radio" name="profitMode" value="brl" />
+                <label for="meta_reais">Em R$</label>
+                <input id="meta_percent" type="radio" name="profitMode" value="pct" checked />
+                <label for="meta_percent">Em %</label>
+              </div>
+              <div id="profitFieldBRL" class="field is-hidden" style="margin-top:8px">
+                <div class="inputWrap">
+                  <span class="inputPrefix">R$</span>
+                  <input id="profitValueBRL" type="number" step="0.01" min="0" value="10" />
+                </div>
+              </div>
+              <div id="profitFieldPCT" class="field" style="margin-top:8px">
+                <div class="inputWrap">
+                  <input id="profitValuePct" type="number" step="0.01" min="0" value="10" />
+                  <span class="inputSuffix">%</span>
+                </div>
+              </div>
+              <!-- hidden sync fields -->
+              <select id="profitType" class="is-hidden" aria-hidden="true" tabindex="-1">
+                <option value="brl">Em R$ (lucro em reais)</option>
+                <option value="pct" selected>Em % (margem sobre o preço)</option>
+              </select>
+              <input id="profitValue" class="is-hidden" type="number" step="0.01" min="0" value="10" tabindex="-1" aria-hidden="true" />
             </div>
-            <div id="mode1PriceInputs" class="modeInputs"></div>
-          </section>
+          </div>
 
-          <!-- Optional adjustments (custos extras, afiliados) -->
-<section class="formAccordion optionalAdjustments wizardStep is-hidden" data-step="1" id="commissionAccordion">
-            <p class="formAccordion__intro">Ajustes adicionais (opcional) — marque apenas o que se aplica ao seu cenário.</p>
+          <!-- ── Personalizar comissão ── -->
+          <div class="adjRow" style="margin-top:16px">
+            <div class="adjRow__icon">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>
+            </div>
+            <label class="check adjRow__label">
+              <input id="customCommissionToggle" type="checkbox" />
+              <span>Personalizar comissão marketplace</span>
+            </label>
+          </div>
+          <div id="customCommissionBox" class="cardMini optionalInlineBox is-hidden">
+            <div class="advGrid">
+              <div class="field">
+                <div class="label label-row">
+                  <span>Amazon (%)</span>
+                  <button class="info" type="button" aria-label="Info: Comissão Amazon (%)" data-tooltip="Comissão padrão da Amazon é 15%. Ajuste conforme sua categoria.">i</button>
+                </div>
+                <div class="inputWrap">
+                  <input id="amazonPct" type="number" step="0.01" min="0" value="15" />
+                  <span class="inputSuffix">%</span>
+                </div>
+              </div>
+              <div class="field">
+                <div class="label label-row">
+                  <span>ML Premium (%)</span>
+                  <button class="info" type="button" aria-label="Info: Mercado Livre Premium (%)" data-tooltip="Comissão padrão ML Premium é 19%. Ajuste conforme sua categoria/anúncio.">i</button>
+                </div>
+                <div class="inputWrap">
+                  <input id="mlPremiumPct" type="number" step="0.01" min="0" value="19" />
+                  <span class="inputSuffix">%</span>
+                </div>
+              </div>
+              <div class="field">
+                <div class="label label-row">
+                  <span>ML Clássico (%)</span>
+                  <button class="info" type="button" aria-label="Info: Mercado Livre Clássico (%)" data-tooltip="Comissão padrão ML Clássico é 14%. Ajuste conforme sua categoria/anúncio.">i</button>
+                </div>
+                <div class="inputWrap">
+                  <input id="mlClassicPct" type="number" step="0.01" min="0" value="14" />
+                  <span class="inputSuffix">%</span>
+                </div>
+              </div>
+              <div class="field">
+                <div class="label label-row">
+                  <span>SHEIN (%)</span>
+                  <button class="info" type="button" aria-label="Info: Comissão SHEIN (%)" data-tooltip="Comissão padrão SHEIN: 18% (demais) ou 20% (vestuário feminino). Ajuste conforme sua categoria.">i</button>
+                </div>
+                <div class="inputWrap">
+                  <input id="sheinPct" type="number" step="0.01" min="0" value="18" />
+                  <span class="inputSuffix">%</span>
+                </div>
+              </div>
+            </div>
+          </div>
 
-            <!-- ── CARD: MARKETPLACES (removido — use "Personalizar comissão" acima) ──
-            (espaço reservado para compatibilidade) -->
+          <!-- ── Ajustes adicionais (accordion) ── -->
+          <details class="formAccordion optionalAdjustments" id="commissionAccordion" style="margin-top:16px">
+            <summary>Ajustes adicionais (opcional)</summary>
+            <p class="formAccordion__intro">Marque apenas o que se aplica ao seu cenário.</p>
+
+            <!-- hidden compat fields -->
             <div class="adjCard" id="adjCard-marketplaces" style="display:none">
               <div class="adjCard__body" id="adjBody-marketplaces"><div class="adjCard__inner">
                 <input id="mlCommissionToggle" type="checkbox" data-adj-group="marketplaces" class="is-hidden" aria-hidden="true" tabindex="-1" />
@@ -580,71 +467,46 @@
             </div>
 
 
-          </section>
+          </details>
 
-          <details class="formInfoDetails wizardStep is-hidden" data-step="1">
+          <details class="formInfoDetails" style="margin-top:14px">
             <summary>Como calculamos?</summary>
             <p>Regra: custos fixos e lucro em R$ somam no custo. Depois, somamos incidências em % (comissão + imposto [+ lucro% se escolhido] + custos%) e calculamos: <strong>Preço = custo ajustado ÷ (1 − incidências)</strong>.</p>
           </details>
 
-          <div class="formDivider wizardStep is-hidden" data-step="1"></div>
+          <div class="formDivider" style="margin-top:16px"></div>
 
-          <section class="formBlock formBlock--actions wizardStep is-hidden" data-step="1">
-            <div class="actions wizardActions">
-              <button id="wizardBackStep1" class="btn btn--ghost" type="button">Voltar</button>
+          <section class="formBlock formBlock--actions">
+            <div class="actions">
               <button id="recalc" class="btn btn--primary" type="button">Calcular</button>
             </div>
-
             <div class="actions actions--stacked formActionsSecondary">
               <button id="saveSimulation" class="btn btn--ghost btn--wide" type="button">Salvar simulação</button>
               <select id="savedSimulations" aria-label="Simulações salvas">
                 <option value="">Simulações salvas</option>
               </select>
             </div>
-
           </section>
-
-          <section class="formBlock wizardStep is-hidden" data-step="4">
-            <div class="formBlock__head">
-              <h3>Resultado</h3>
-              <p>Confira o resultado por marketplace selecionado.</p>
-            </div>
-            <div id="resultTransparencySummary" class="resultTransparencySummary" aria-live="polite"></div>
-            <div class="actions wizardActions">
-              <button id="wizardEditData" class="btn btn--ghost" type="button">Editar dados</button>
-              <button id="wizardNewCalc" class="btn btn--primary" type="button">Novo cálculo</button>
-            </div>
-          </section>
-
-
-
 
         </div>
       </div>
 
-      <div class="wizardResultsContainer is-hidden">
       <div class="card stickyResultsCard">
         <div class="card__inner">
           <h2>Resultados</h2>
-          <!-- Comparativo removido para priorizar leitura rápida do preço ideal por marketplace -->
           <div id="results" class="resultList"></div>
-
           <div id="reportRoot" class="reportRoot" aria-live="polite"></div>
-
           <div id="shareBox" class="shareBox"></div>
-
           <div class="hr"></div>
-
           <div class="actions">
             <a class="btn btn--primary js-cta-whatsapp" data-action="cta-whatsapp-community" href="https://chat.whatsapp.com/Ff9jaV8Lj1K4Qm2bNNIQdy" target="_blank" rel="noopener">Entrar na Comunidade WhatsApp</a>
             <a class="btn btn--ghost js-cta-instagram" data-action="cta-instagram" href="https://www.instagram.com/macenorafa/" target="_blank" rel="noopener">Seguir no Instagram</a>
           </div>
-
           <p class="footnote">Sem spam. Só conteúdo útil para vendedor de marketplace.</p>
         </div>
       </div>
       </div>
-      </div>
+    </section>
 
       <section class="yt-section" id="videos">
       <div class="yt-header">


### PR DESCRIPTION
## Summary
Removed the multi-step wizard interface from the pricing calculator and consolidated all inputs into a single, flat form layout. The calculator now displays marketplace selection, cost inputs, and both price analysis and margin calculation modes simultaneously, eliminating the step-by-step progression.

## Key Changes

### UI/UX Restructuring
- **Removed wizard stepper component**: Eliminated the 3-step progress indicator (Objetivo → Dados → Resultado) and all associated wizard navigation logic
- **Flattened form layout**: Consolidated all form sections into a single continuous form with no hidden steps
- **Unified price/margin input**: Created a side-by-side layout (`priceOrMarginRow`) allowing users to enter either a sale price OR desired margin simultaneously, with an "or" divider between them
- **Simplified results display**: Results now appear in a sticky card alongside the form rather than as a separate step

### Form Input Changes
- **Sale price field**: Added new `#salePrice` input field for entering the selling price directly
- **Automatic mode detection**: `getCalcMode()` now infers mode from whether a sale price is entered (real mode if price > 0, ideal mode otherwise) instead of relying on explicit radio button selection
- **Removed per-marketplace price inputs**: Eliminated the `mode1PriceInputs` section that required entering prices for each marketplace separately
- **Reorganized cost section**: Grouped cost, tax, and weight inputs into a 3-column grid (`row3`)

### JavaScript Logic Simplification
- **Removed wizard state management**: Eliminated `wizardStep`, `setWizardStep()`, `renderWizardUI()`, and related navigation functions
- **Removed mode selection cards**: Deleted the interactive mode selection UI that required users to choose between "real profit" and "ideal price" modes
- **Simplified calculation trigger**: `recalc()` now directly scrolls to results instead of advancing through wizard steps
- **Removed step validation**: Eliminated `validateStep()` logic as all inputs are now always visible
- **Updated price analysis**: Modified `renderCurrentPriceAnalysis()` to use a single global sale price instead of per-marketplace prices

### CSS Additions
- **New `.priceOrMarginRow` styles**: Grid-based layout for the side-by-side price/margin input section with accent border and gradient background
- **Responsive adjustments**: Media queries for tablet (768px) and mobile (480px) breakpoints that stack the price/margin columns vertically
- **Row3 grid**: 3-column layout for cost inputs that collapses to 2 columns on tablet and 1 column on mobile

## Notable Implementation Details
- The form now auto-calculates on input changes via `debounceUxRecalc()` without requiring explicit step navigation
- Marketplace selection and custom commission settings remain functional but are no longer gated behind wizard steps
- The sticky results card displays filtered results based on selected marketplaces in real-time
- Default profit mode is set to percentage (%) rather than fixed R$ amount
- All wizard-related DOM elements and event listeners have been removed or stubbed out as no-ops

https://claude.ai/code/session_01AFJwqfESbWrs6qpfAyqh8M